### PR TITLE
Adds `--min-residues` and `--max-residues` to `search pdbe` sub command

### DIFF
--- a/src/protein_quest/cli.py
+++ b/src/protein_quest/cli.py
@@ -41,7 +41,7 @@ from protein_quest.structure import structure2uniprot_accessions
 from protein_quest.taxonomy import SearchField, _write_taxonomy_csv, search_fields, search_taxon
 from protein_quest.uniprot import (
     ComplexPortalEntry,
-    PdbResult,
+    PdbResults,
     Query,
     filter_pdb_results_on_chain_length,
     search4af,
@@ -775,8 +775,8 @@ def _handle_search_pdbe(args):
     else:
         rprint(f"Found {raw_total_pdbs} PDB entries for {raw_nr_results} uniprot accessions")
 
-    rprint(f"Written to {output_csv.name}")
     _write_pdbe_csv(output_csv, results)
+    rprint(f"Written to {output_csv.name}")
 
 
 def _handle_search_alphafold(args):
@@ -1169,7 +1169,7 @@ def _write_lines(file: TextIOWrapper, lines: Iterable[str]):
     file.writelines(line + os.linesep for line in lines)
 
 
-def _write_pdbe_csv(path: TextIOWrapper, data: dict[str, set[PdbResult]]):
+def _write_pdbe_csv(path: TextIOWrapper, data: PdbResults):
     _make_sure_parent_exists(path)
     fieldnames = ["uniprot_acc", "pdb_id", "method", "resolution", "uniprot_chains", "chain", "chain_length"]
     writer = csv.DictWriter(path, fieldnames=fieldnames)

--- a/src/protein_quest/uniprot.py
+++ b/src/protein_quest/uniprot.py
@@ -44,7 +44,7 @@ def _first_chain_from_uniprot_chains(uniprot_chains: str) -> str:
 
     where:
         chain_group := chain_id(/chain_id)*
-        chain_id    := [A-Za-z]+
+        chain_id    := [A-Za-z0-9]+
         range       := start-end
         start, end  := integer
 
@@ -140,6 +140,9 @@ def filter_pdb_results_on_chain_length(
     if min_residues is None and max_residues is None:
         # No filtering needed
         return pdb_results
+    if min_residues is not None and max_residues is not None and max_residues <= min_residues:
+        msg = f"Maximum number of residues ({max_residues}) must be > minimum number of residues ({min_residues})"
+        raise ValueError(msg)
     results: PdbResults = {}
     for uniprot_acc, pdb_entries in pdb_results.items():
         filtered_pdb_entries = {

--- a/tests/test_uniprot.py
+++ b/tests/test_uniprot.py
@@ -299,6 +299,13 @@ def test_filter_pdb_results_on_chain_length_unchanged():
     assert result is pdbs
 
 
+def test_filter_pdb_results_on_chain_length_badrange():
+    with pytest.raises(
+        ValueError, match="Maximum number of residues \\(13\\) must be > minimum number of residues \\(42\\)"
+    ):
+        filter_pdb_results_on_chain_length({}, min_residues=42, max_residues=13)
+
+
 def test_filter_pdb_results_on_chain_length_filtered():
     keeper = PdbResult(id="1AAP", method="X-Ray_Crystallography", resolution="1.5", uniprot_chains="A=1-100")
     pdbs = {


### PR DESCRIPTION
Also
- command outputs additional `chain_length` column
- assumes range is always given in a uniprot_chains string
- caches props in PdbResult class
- use type alias for dict[str, set[PdbResult]]

Fixes #43