### PR TITLE
Download  PDBe updated version by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -331,7 +331,7 @@ Some tools (for example [powerfit](https://github.com/haddocking/powerfit)) only
 work with `.cif` files and not `*.cif.gz` or `*.bcif` files.
 
 ```shell
-protein-quest convert structures --output-format cif --output-dir ./filtered-ss-as-cif ./filtered-ss
+protein-quest convert structures --output-format .cif --output-dir ./filtered-ss-as-cif ./filtered-ss
 ```
 
 Or to inject Uniprot accessions into structure files use

--- a/README.md
+++ b/README.md
@@ -331,7 +331,13 @@ Some tools (for example [powerfit](https://github.com/haddocking/powerfit)) only
 work with `.cif` files and not `*.cif.gz` or `*.bcif` files.
 
 ```shell
-protein-quest convert structures --format cif --output-dir ./filtered-cif ./filtered-ss
+protein-quest convert structures --output-format cif --output-dir ./filtered-ss-as-cif ./filtered-ss
+```
+
+Or to inject Uniprot accessions into structure files use
+
+```shell
+protein-quest convert structures --uniprots pdbe.csv --output-dir ./filtered-ss-with-uniprots ./filtered-ss
 ```
 
 ### Convert structure files to UniProt accessions

--- a/src/protein_quest/cli/retrieve.py
+++ b/src/protein_quest/cli/retrieve.py
@@ -39,6 +39,10 @@ def pdbe(
     output_dir: OutputDir,
     /,
     *,
+    archived: Annotated[
+        bool,
+        Parameter(negative=""),
+    ] = False,
     max_parallel_downloads: BatchSize = 5,
     cache: CacheParameter | None = None,
     _: Common | None = None,
@@ -54,6 +58,10 @@ def pdbe(
             with `model_provider == 'pdbe'` are used. Single-column CSV files
             are also accepted, and the first row is treated as an ID. Use `-` for stdin.
         output_dir: Directory to store downloaded PDBe mmCIF files.
+        archived: Retrieve archived versions.
+            By default downloads an updated version of the PDB archive mmCIF format file.
+            The updated version is generated with standardisation of vocabularies,
+            and addition of connectivity information for every chemical compound present in the PDB entry.
         max_parallel_downloads: Maximum number of parallel downloads.
         cache: Cache options including no_cache, cache_dir, and copy_method.
         _: Common CLI options.
@@ -64,7 +72,9 @@ def pdbe(
     cacher = to_cacher(cache)
 
     result = asyncio.run(
-        pdbe_fetch.fetch(pdb_ids, output_dir, max_parallel_downloads=max_parallel_downloads, cacher=cacher)
+        pdbe_fetch.fetch(
+            pdb_ids, output_dir, archived=archived, max_parallel_downloads=max_parallel_downloads, cacher=cacher
+        )
     )
     rprint(f"Retrieved {len(result)} PDBe entries")
 

--- a/src/protein_quest/pdbe/fetch.py
+++ b/src/protein_quest/pdbe/fetch.py
@@ -32,6 +32,8 @@ def _map_id_mmcif(pdb_id: str, archived: bool = False) -> tuple[str, str]:
 async def fetch(
     ids: Iterable[str],
     save_dir: Path,
+    /,
+    *,
     archived: bool = False,
     max_parallel_downloads: int = 5,
     cacher: Cacher | None = None,
@@ -63,7 +65,7 @@ async def fetch(
 
 
 def sync_fetch(
-    ids: Iterable[str], save_dir: Path, archived: bool = False, max_parallel_downloads: int = 5
+    ids: Iterable[str], save_dir: Path, /, *, archived: bool = False, max_parallel_downloads: int = 5
 ) -> Mapping[str, Path]:
     """Synchronously fetches mmCIF files from the PDBe database.
 

--- a/src/protein_quest/pdbe/fetch.py
+++ b/src/protein_quest/pdbe/fetch.py
@@ -6,36 +6,44 @@ from pathlib import Path
 from protein_quest.utils import Cacher, read_ids_from_csv, retrieve_files, run_async
 
 
-def _map_id_mmcif(pdb_id: str) -> tuple[str, str]:
+def _map_id_mmcif(pdb_id: str, archived: bool = False) -> tuple[str, str]:
     """
     Map PDB id to a download gzipped mmCIF url and file.
 
     For example for PDB id "8WAS", the url will be
+    "https://www.ebi.ac.uk/pdbe/entry-files/download/8was_updated.cif.gz" and the file will be "8was_updated.cif.gz".
+    If archived is True, the url will be
     "https://www.ebi.ac.uk/pdbe/entry-files/download/8was.cif.gz" and the file will be "8was.cif.gz".
 
     Args:
         pdb_id: The PDB ID to map.
+        archived: Whether to fetch archived versions of the files or default updated version.
 
     Returns:
         A tuple containing the URL to download the mmCIF file and the filename.
     """
-    fn = f"{pdb_id.lower()}.cif.gz"
-    # On PDBe you can sometimes download an updated mmCIF file,
-    # Current url is for the archive mmCIF file
-    # TODO check if archive is OK, or if we should try to download the updated file
-    # this will cause many more requests, so we should only do this if needed
+    fn = f"{pdb_id.lower()}_updated.cif.gz"
+    if archived:
+        fn = f"{pdb_id.lower()}.cif.gz"
     url = f"https://www.ebi.ac.uk/pdbe/entry-files/download/{fn}"
     return url, fn
 
 
 async def fetch(
-    ids: Iterable[str], save_dir: Path, max_parallel_downloads: int = 5, cacher: Cacher | None = None
+    ids: Iterable[str],
+    save_dir: Path,
+    archived: bool = False,
+    max_parallel_downloads: int = 5,
+    cacher: Cacher | None = None,
 ) -> Mapping[str, Path]:
     """Fetches mmCIF files from the PDBe database.
 
     Args:
         ids: A set of PDB IDs to fetch.
         save_dir: The directory to save the fetched mmCIF files to.
+        archived: Whether to fetch archived versions of the files or default updated version.
+            The updated version is generated with standardisation of vocabularies,
+            and addition of connectivity information for every chemical compound present in the PDB entry.
         max_parallel_downloads: The maximum number of parallel downloads.
         cacher: An optional cacher to use for caching downloaded files.
 
@@ -46,7 +54,7 @@ async def fetch(
     # The future result, is in a different order than the input ids,
     # so we need to map the ids to the urls and filenames.
 
-    id2urls = {pdb_id: _map_id_mmcif(pdb_id) for pdb_id in ids}
+    id2urls = {pdb_id: _map_id_mmcif(pdb_id, archived=archived) for pdb_id in ids}
     urls = list(id2urls.values())
     id2paths = {pdb_id: save_dir / fn for pdb_id, (_, fn) in id2urls.items()}
 
@@ -54,18 +62,23 @@ async def fetch(
     return id2paths
 
 
-def sync_fetch(ids: Iterable[str], save_dir: Path, max_parallel_downloads: int = 5) -> Mapping[str, Path]:
+def sync_fetch(
+    ids: Iterable[str], save_dir: Path, archived: bool = False, max_parallel_downloads: int = 5
+) -> Mapping[str, Path]:
     """Synchronously fetches mmCIF files from the PDBe database.
 
     Args:
         ids: A set of PDB IDs to fetch.
         save_dir: The directory to save the fetched mmCIF files to.
+        archived: Whether to fetch archived versions of the files or default updated version.
+            The updated version is generated with standardisation of vocabularies,
+            and addition of connectivity information for every chemical compound present in the PDB entry.
         max_parallel_downloads: The maximum number of parallel downloads.
 
     Returns:
         A dict of id and paths to the downloaded mmCIF files.
     """
-    return run_async(fetch(ids, save_dir, max_parallel_downloads))
+    return run_async(fetch(ids, save_dir, archived=archived, max_parallel_downloads=max_parallel_downloads))
 
 
 def read_pdb_ids_from_csv(file: Path) -> set[str]:

--- a/src/protein_quest/structure/convert.py
+++ b/src/protein_quest/structure/convert.py
@@ -75,6 +75,7 @@ def convert_to_cif_file(
 
     Raises:
         ValueError: If the requested output format is not supported."""
+    logger.debug("Converting %s", input_file)
     if output_format not in cif_output_formats:
         msg = f"Unsupported output format {output_format}. Supported output formats are: {cif_output_formats}."
         raise ValueError(msg)

--- a/src/protein_quest/structure/files.py
+++ b/src/protein_quest/structure/files.py
@@ -58,6 +58,7 @@ def locate_structure_file(root: Path, pdb_id: str) -> Path:
             root / f"{pdb_id.lower()}{ext}",
             root / f"{pdb_id.upper()}{ext}",
             root / f"pdb{pdb_id.lower()}{ext}",
+            root / f"{pdb_id.lower()}_updated{ext}",
         )
         for candidate in candidates:
             if candidate.exists():

--- a/tests/pdbe/cassettes/test_fetch/test_fetch.yaml
+++ b/tests/pdbe/cassettes/test_fetch/test_fetch.yaml
@@ -1,178 +1,177 @@
 interactions:
 - request:
     body: null
-    headers: {}
+    headers:
+      Accept-Encoding:
+      - gzip
     method: GET
-    uri: https://www.ebi.ac.uk/pdbe/entry-files/download/2y29.cif.gz
+    uri: https://www.ebi.ac.uk/pdbe/entry-files/download/2y29_updated.cif.gz
   response:
     body:
       string: !!binary |
-        H4sICNnR+lgC/zJ5MjkuY2lmAMVd62/jOJL/nr+CwOLg6UNbrbft3Q+BbCuJZ/xa2+nu9GIgKLaS
-        6Ma2vJLT3bnD/e9XRepBUpSdZAa49OzGEat+LBarisWH6E14DAPzzuxd/I1cBNH+mL5o8YYQgs8I
-        fRg+b+JjsE72D0m60zbx+hjsw11E2M9ut44fgsPm/icWqcm/R2kWJ3skdzSz01NTbZN1eGRkT8fj
-        4e+fPlFsDbC1JH38hERQHKZxlH0Ks3Ucf5IrB3G3SXIILoINtOs+zKLA1MqP0C51wTrZRORiPuwX
-        7S5+8JlPiN8ftW23Yxr02ZcvSDkMDLOn6+wxVzEKU1WSRtvwGG20zT3T2YlyKp26FNR0hK4Jji+H
-        ExDRMYy3GWuHcTvzyPM+O0SgoDjakJZ3tfIXxJouWznFyvsiUvRnn0dTn6wWd/PlaEoGs8l87H/1
-        h2Q1I958PsoZzTvrV5FxuVrcDla3C5/MrsjSv5740xXxRqPr8YRcLWYTsrrxiTe5G89Gw3bfX3lk
-        7s9Xo6FPfvH6H8nCX46Gt/6SWHrbcj6U8v02Faq5aC1n49vVaDYlQoUDkG34nx+JNyWj6dCf+/B/
-        09X4jlzNxkN/6H9dLbyBPx7fjr0FGc4mHrQN2G5uJ8AhSrXwB7eL5WwxX8xW/mhaSPLPwUTSJeMi
-        YltMB8X/SKaTxUdi6pWUpcr7nis26R/qJqG+Jv7qBgqgR9qzr6Ph6Bt0BF9vu6zXaNv6Bw2aBipE
-        Uo8CeldX/mAFvTi9mi0m9Jk3Jssvo9XgZjS9vmRiGryYF//I23u3kjpYKeXVwmNdnbccn1GN5GIW
-        AoK+l8MlmYywF6APCrRSK7/2G6oDEcUqeQX8yzfc3znrMdpmFxpk1/UOFjt+hcVOPl9ff/488t5m
-        s07bNqHTvTG419Rb+WQ+G99NwIZuiFnWb3qvqP+38eerq7fVbrht02ionfPX3/4/Wm8U/TvwdGWg
-        GdwA5bloA4GsqwpkZhXI+ouBQKGV3mZL3oatUttys2eRD2jAHvkCrVu0mRH7xJ9+Hi1mU9ScRkbL
-        3GMn/YUH/kqWc28KnntdhJsvNz5U8wViK7jeb2S0ApZTDuh5c1WLzC+/WaIuBou75Qrdmm8Li2yj
-        6fJ2PJq2h/71whuiMP70292EumOubALB4EbsZmyyWYbgf34R5WihQ3oQR+6W0Gaoijp+FQikAFAY
-        TQH31TBEOHwwX/VzNRVk3/ye1G/fRtNBuw/RndMpdtr4240/mviL1pIMR0vfW/rqjqyMi7WYICD5
-        ZTT6AKMHGkMZ+b4O6g2uheayvaz5Da0GGU39U1cnn//+mdz4X72r8e1sMRstZzC8gIHMxp+oTUFg
-        /IroRfNHUvQ9NUi8WgOsX4tmfvM7f7GG0chpY0pZvRWBIOBqTl6p2fevpUqtoeSEXG0ewjOpydWo
-        vxiNS++4nY1UEcGuIoI36UtVvV5RVWwlbWJ2P5BfqJ9ORtPRhA3Cn33of78SvVTr4os4vLfyHGM+
-        BwuEJopmfjsTO6E1mY0h/6BZyt3Ug0izJMvRBB5QfUpBiqBqyC8EoP5ObeZD2QdFBbMvNUN6i/3I
-        2RC0YT4HPYtWUoasyVgRbE/hQ3RWKh2SmQp08Ff3o8OF2w+lac7tv94fVld+m/nEL129beofSt8o
-        3fDXoVStMp6jIiFMQdRdjQacMIOZd51bx5U3WM0W5OuoFt1/u52OVt8I7UOUdjS9GfVHSMyAAKcs
-        m/pfgX00KtUym0jyTWZDf3xGEe3lsuzYPjwfEowGBNKD0nRyiyr00P918K4E8EqZADqKxHtSG8ja
-        0DHg06DrSqFc0lNZP5EmAzffrNfbpJQ7VaLqbcid0P7+VpvPZcfw+Jxp7Bebmqp+FtARDax0Fh/Q
-        Wbzyh03t1byb6JBkMDOH/ynrpRPiBt5DmqyjLHsX7/KaLT40yaw1MabR+vsmiPfxMQ63QS5+nOyR
-        EKUwdVC2YbZhYtAkNky+cRUixPWI3SE8xvdbXv67V3RRkD3UZb58DeMufSfjOnsD4y46PiWbDPTz
-        Pdomhx2uJqxBQY8JU/klv4TB1mbCZ2BJtXzZQnhGq0jSTbwPtzAvHyTbbXSMo/Qj+VVrEYi4F61x
-        +Bjukx/ZHy8wO4CHJs7fwx/hSwhjqbZAMmLBMz/Oov19lD5+JEN8aLM1p3V8pGtBWrMVH9J4F4L0
-        HPExPm7V3tKaJNto/bwNU9IPszgj0OHE271sk3jT/p9+dAz/l8yT7csuSQ9PcbYDUTjc/0qeU2hq
-        EN7fp9F3waTB5LVpeNxq3jrcaMt1rN0uPRXv92T7vBOEM/QuT3gIH6PgIU6zoyy84fasOuk2rFNS
-        AyjJXqIwbYgAOmTeCiHjTeAtVxO+gVNv6bk87Tp5bnDU22UD5mi5nHJ0um522l3btBvIB8shEchh
-        FsZR3ifJH8Hh+X4bZ09R2th60Q8Adv58P4no0qbRs3um7ZykHkKWmXeTZugd6xNqQjMMw3R1nXZd
-        5TAFSuEf5d90TU8uzT1Kflz6U2HYNb8Cx+JKZQ8DFxNK95vwGX2txZph8aXfnsKEK0O340qXSRoD
-        OML2KYnDl14n2022ftrFm+NHMoZyly+92ibH3JXZT4cvHeCybcKVd4V6pfhAenypHClw6sxiRbTd
-        qsa8fJijxdto/3h8CkKuuKc5PV0qv+e9ztT0jkyw5ghsUzONkiDcP26jINwenspKerqmS+X3EGnI
-        ifLHcLdT838L2Po0L0BRRo33eR//+xkk+BlnZUAPspcdhP705WxOUGirZMgO4RrkSZPnA126Dm7a
-        EzGkzsGR2H8tnpEK8/C83QYNEJc8NcofZNHxGO8flXIJ1CMYtlYhDM9ZsH/e3Ue18Gb0eL+ERsdH
-        up9Rfs6X0PO/snQdsKGxesYiQZSt0/hAtyPKEkwSYAgJfkTx49NR4mDyBMlDsGNDTZRJFNFaerB7
-        ZhFAevyQho84QFePy6V9gxxwkIJ2Zy97aR0a51NFqtoxba2n9yBgXMK/lrjCyKXMbrfTdntmC7Vs
-        kh+QEKBG9+Gx/Fz/MbqaDkk2hJtL+u/sT26KrC3MECDP0vK/qUkainJujwmTbMWSOwSo/nz+kS4X
-        0v//WM1LFNNZqpuPZOAv/P4CEv/P3pJNt6WFGyD57AEWTAE8+6M0PWqPoKo5/sqT91xs7BehSSrN
-        SeTUFpt/Wkh0iMAIN9EvY1yUE7j32XETbOP9H5AMKLj3iYp+l+yTnbJja/TUFrPo30Gyh2QDPBSs
-        m5uN5KvVr+OBXHN/mueYwoCl0pyS/Bimj9ERyLEEpmGpZGyC/1M+lIrrn3oZ+K/i6a4YxOWCpwja
-        lqBHGmR8tyR7/GiSsX/LPlpgXmP2EfwSJpb0o1N9dMFWPfxYzgDzKjAmgXc3GZPRQM7UCH+IDCfJ
-        wy1M9CDvgij9sA0x/mbh7rCNTvHcR4+0h1Ff0qRDRR5Br76OPEkhn4HUO4AUgXUrHWxbN7PJjCy9
-        +cinC3yneSFwYJflsYOtv6lZ9uv7GOzoJzoEp+Weq7sNHEUUVoc3sODn9TFIo4cTcxbaHRxlsS2s
-        Sqan8xpt02KAZwdFUzmGE9FIEuOEq18qKMNt/LhHQ4j38kAtUYLM4RrXBPLd/3xOoTu621GTx1mC
-        w+xJBVMHZEKcCrUSA/5u7hkFAxUJki6cDdQ1X+RLCp7GYObVGVDrpT5fLZXAFcT7TN1dUg3gi7Ua
-        3LM1oAefruFEV6t7m3IhQ2PDMTM5UZGq6SrJSlpV0wlkPufqkBrf2HqcwwWqvjRfx1DJ1xEmlk8R
-        jWkHlsNWf+ZpbPWARj0c4Wkg50uK6Wb5gPXvyz7Zv+wyoSRPcFXPyqQXR63WuJ3nJQQTEEjdW+QF
-        xzM8rlB6bWtgkZsOmZKZyWZ73Z6m93AeejO7gXxj3y6S2WqRjy2YV57fujHJrKXIPi9wpFXLASUD
-        UQ6X3BhWJYhhGZrRsQADBu4GjLtlBVFiOGQK4pi4tW3YHc3oOeQCB3Q1BpRM78aFVhCjBxgGJ4fr
-        aEYXogimCmoMKJHkcCQMA+Sw3TzF/nk4qqbCeaxixfl8h080v7YX3h1kzFdXC2+QH83IqdfpS3YM
-        t9x8y+LqCvLihiHPqNFBwpbhoLSLwkwcOtR0k/B4fIp+5LSGhr3WQHqIII/ZY0KzxSb3FITVnK76
-        mc5Av/UW4bT1R9H6UpmGmkxW6aWa7BjtDvLUtoEs4JKNBrLDjajsruY0EKK/H24CGJQeoxN4bN5b
-        Vgtzrj49X0LwABEZjUYk355aki94nmHWX3lgnEPC9l/p4Yp8ovnFo1shy9n4M5SXm8PeCjLgyfWn
-        yZh40yFufBdb8rpmTmAeNplNR7fwYQCzvBVMxHTNIBOyWoyWpH97dQUQ8xvaUGS39P8g3G66lk/I
-        NvHDQ9q4cGxUFOHuPqan6sRuMeiai4KGU85lRSGbSFVPJQxyRutjkmr536qkvkaaf5AaMBgMFcQN
-        U8nWxFtMZktvNCCm6ZDdDtlbCn7a+Wtcb1zzmyeXarlOpME5dRpuYraw2tBiZdsrrh/h9yhfcmsO
-        LTUutqoCGf36KU128GwdJGmwDZ+jYBdgVJiouDiGJG1aglLXlT89pMkxWdO4w+keRpDrsQ+m/9kf
-        +9Pr1U2rESdbh5h0Q9APaj35s52GL2rlBpWaRHs3zhBXH3F9Xet2TFc/x8JvNhiaLkjEJpEn+9qo
-        UbNfaqNY3k0HN4vZajGb1vhOLZu0/OUCj+N4Ezpujoam1TZbNYgiBcJuP6bQUG7LkiKcZbiPwh2M
-        08jEKlGzCIrmtjRklat5gm1c7fHkDgZZ5HafCeZX07ch0RVbC6SZ7uT6cJ4/5KTJfRal3yOYFKUx
-        Gi1V3+MuDHDDxELLOEt5lXtVTreBDzBsP1Ob2yY/pL0qtgquon2CnFSg1SyOtFiSvc9UbXLdGmW4
-        3Ta4f6HNPMc4JDDPud9GAnbP1ixJ8QvIbh+jYCTLAONaTybNXnbB93D7HDXXTteZoyPAfQdpqSpH
-        BZ2j9bim93EiHXyBOA1airJjvAurPXnL1gzLlnDTaPO834T7tbSzZ2k93vCC7Knccaibn6Gkq5tf
-        jY72aq07xf4USGUrAVK7RlrrLtbBMA9xZNKGntI1x1S2qd5dlzId5Lj7qqtKZIvvex6y3gNAWuoe
-        Yk1Bhp9PbeU0ZfQ5ytmtoLrbl5WfHc2rzi15VuMldlm8eYY0yRvOi7VGhZUjTznXKFSk9l8QzzFO
-        cKl9WaiJSrfNuOjVvIOh5rlq5tFkzeGLNuvnY/LwQO08CO+zqzP18Dxg8CqWkzy0nnSXyYyithsc
-        qnZkoAzDAl/NZ2W+0oVztsIpT/cuBlOxexfBQ4gJaKM95A5rwsDaU3M22YRCKSXPIviRpH+cqM02
-        9CbOhzSKmjldXbdOcQZRmioS0svzPIGco1+e6oEGOR3NOuFeTY0zbBXTIUzDHe6YZK9QfVkRrqPG
-        ++NZnmS9fj5g3Ax28f7MTqSCJ/z5Sp51ktKXrTDzWCcRONhVEhyT4Gpd69web/TNfJISgc/pVnxs
-        EMdh5FygNjXX4RSPeyFJ0P+X8Tv8d4qxbRia7dQZzd/hv1OMwNfV63zW7/DfyQp1zVILero+Mfhw
-        bNY72My3sUG2+R3dZZdsom3QMP3Fn4m3/K2JjXpA8EeWbE9ZmIrn/gwPm5rkjN83P3A2eh/RSVws
-        9plm6g1saJlNbLrQ0wJb9pSy/efXsYFvr1NIxTBvijdBfSESflYw67u9vpndrirmEyqX0p6bu+Fi
-        du1Pl+QGZt0wD/SnxBsO2RoULlAtRuwA8mw5wqxoqbXkph3DFM+isC54XTrAGoIejYsk6Q7TM7bm
-        z6/ElKf7F/587A18XCiTawf7hNnlIV4HxycAgnypLkat66HKKMEFe5gsQmKX743T3DSr1oG+jia3
-        EzIe/eaPRzez2bDVCMMhBHjOOViHWaSsehFc4ZiTReWyUb2nFt50OJtIjJgUw2Ac+MvbYNHohIZt
-        nOKjlSud1+X4ChbgmIzPOH3NYgvmwxOeCjw7HnN19U8aqqU5tqXkWwSD9Dle/5E9hfs/guF8dLLv
-        BUY6/te5T/L0Ma2Ua3lNPXXGS36qAmlhdjw/Xzk1T2EQ65f19uRkZ+wtV6pqiyn9MYH8Fxfooio3
-        KOZ0Jzj2z1Av+GG4pnXrZxm28WPIbTLKDAJtHj/FMfwUwzE51pZvuAGfcZzNx4VUnOc5kfvnaX+1
-        JZlzQyynCVqxEyk/3kTf8XgOnmdtLssjjYKkPGInF+TbUPUCydYaCfKkMnh43q/Z4bs0uE/2m5x+
-        E2zkqGBa5a9L4lhKo70sYRKM3MGm5lDir0vSDMNOgpbi8LvjhuYYPfzV63YQpqOfg8nFEbfY3yLN
-        Jn6KNikefqd4BoflaIbl4i8dTAR183oYk4MxbK1jdpml6UBtvh7G4mF6mgnKMZwcpvd6GJuDeYtu
-        1k8xglCjqo9eZodO85huuidgHiPIvrbhPsqKXhcy0R4zPwpjdV8FQ3v9nR2+v9/UxHgnjCzGu2Bw
-        cquU5+0wSnneAvPz5Yk6uUJH74WRZHoLDOSduPEIeVdNP++DqennLTDFIW06BxEFejeMKNC7YJ74
-        4P5nYXh53gVT77I/CVNI9KYOX9PGxMc/55o5jMqp3gbDgnB8/JPScAPe+2Gyv0Y32V+jm+yv0U32
-        1+hmm8C8mJ4iCfp/wsMFmPd7eBo/xpsidRMH4Dfp5gACxGs8QSSvaL4TBkV6Xyz+m5C2CltD75xD
-        iTB0GsG9qXKPRxufM/ZSnK7getWUwmhkPDWv0CxXVaO8ylxbfDddBdfZ1XrIwzoqxrObEYYuLAYq
-        q3xoWIdwu9Z5xvqqwuV5ORcKWz2vy5qcxlkmxY7J5ak2ndh1q85wn9iBFE5Vn3if96K1pCTPaUSS
-        B5JF7I2p/AWThzTZEQgsJMzf8KWv3RXHK3/x7j8StiEZZeUVSuH2GKV73CU/FO8B45m3ViWN8GKY
-        0GXNL2KJzMoV5EuJaOAt61ukl0oknHuLp9K4g/J/RC/gC5v60Q7x5HpJRnGLv+j7ffm9H+z6lZaC
-        5Rj9PIqvBAositexWvxSQg4XQlrDzjfzD9jLJltcx8Iz+OsnmLXH5fHmGiUoJL+PQSjj3/jhn5dv
-        1HlkCv/wPbmLPv1oSmq8j5P8eGtxpK94SRjF2oXHNP7ZfORWRZzAyPVT2JsxcMqqs3OHpxjKPRL9
-        lQzWmxhMTqTXMphvaoP5VpGst4pkvVVL/JbVa9oQfKfHIJlYeQ2voTffSG8J9PQezmOyowfVTp/W
-        yi2Po35IITgH+FJK9pDXVZofvtxumx3nVRx8G/RXcVhv4zB/F/T6Oo5Cqq7ZdV7H8UaprDdLZb1Z
-        V1YllWm5PeMEB2+Agk2dYTDfymDJDNwVIciJw48G0fQ+2ZKLAbmYkotZjQjhNfYOOL7Azj+lUbn6
-        k45mBRz3fBvew1hH/5Y48pLtUV2A7680sODpLWUJP2DIZfi6jlRQvSNWvCTElw7C9LgPfiqevSie
-        /bfwrDygIDxlRwIg0Yr+/Rx/r4tC77HZ4miZPoqylC8cSS2gz1WaogUqRbECRXeUymDZCX2j1lvN
-        JuzmChxc8VgUvnTjEYOOuW0LpgEd4mgd3SKko/VsPQ/DxLQ1w2CrwSTnmbJBOIeEggEZeArIXsci
-        rtbF14TwJR2rhIR6HBES+StIi0LWpQRRuiZA2rgICyBGt4Q08fyECClIaRMyg381SEczHRsPbXZM
-        hLR1m4N0LRFyJkA6VMq+ouEmoHQ1w6K6tNxSSsvVzK4kZZ+HdCnktQLScSyA7LkuvmDiuqUuLaxA
-        grzmITsUcqjQpQOC4aUqMEx1NavrFpC2pXVNCXLIQ3YppK+C7Jl4JMU0TbzWA1fMcylBG3LDfR6y
-        R+3ym6J7ujA9pVeA2Ahp2HzDZbv8xkMaemXq/i2FNJkujU4XL0Q0oMW21rUru9Q1G3VpUUjKI5o6
-        OEJp6iKkRSFN18E9ZdvoFJCGq3UkSNHUDbMydR7ShIb3QLye3cFJes+sIB3WPTykKKVVmToPaYDd
-        mADp9nR6Phz9Moe0NbBYAVI0dVB7aeqilB3bpDZuopSOWxqR0QXHkqQUTB1qL01danhHx3iBkABl
-        O1z31BoumDp0KJq6IUPiEUYXpQRgPElsWLyUhgQ5NHjIDoU067rsdnVwG7wSiS5qmKWU4D01SJOH
-        7JZ2ie8bIqTFjKgDURGPhFNdWo7Ld08HSND2cx7JLnulXUqQFrgNWI/uIpTr9jhIxxYhRbuECFvY
-        pQTZgx6Hfkfr0emqU2XqhilBigOFUdqlAOloho1S2t0e269z+O7pipCiXZpmaZeSlC6YCrZYpyfS
-        OwbXcEuXpBTs0rSoXRp1SAP6VWdjDyD3OhwkhFAR8po3IpN6z7VZh9ShXw0YDGnY6OrlQGFYbNAV
-        IHkjAh0VRoQvviKknUPCQAHdA5krHvJzO24B2YO4xzaHSc4jjeNuaUQSpK07BAdDYAX31LtW1T1d
-        V4SUjKhTGpEACfKBlIZmYSSCv9yeW0E6pgQpStktjUiANMCesceNLpPSsbmGmxKkZES90ogkKXtg
-        kdAvODTSgGxVkB1LklIwIksvg5ukSxMagJ4O1oNxCQy/klKGFIKbZZTBTZLSBiMCWWHoZb6kV5CO
-        LkEKwc0yy+AmQII9Q9iwwW1MKmWPh+z0ZEjeLi3qPb5CShc6BHTYRbvEwdesorol97gvSEm9x1dI
-        6YCP2DRxRUj8PotKSluGFKSkY883RfegJWKyBVDtDkRds4LUZVMXsg1IwmSHdIrMrYeDTg96GgMy
-        b+oG6tJtckirU3PIHNKA4IvODR2POTF+HwbTJbiUI0JKiXW35pA5ZLfbRcguoIAR2Rjdi/Tf7EiQ
-        opS9mkM6LKrrMIKDX5rg0O08sy6k7EhSig5p6zWHdIrEuouQPQh/+FeHg3QkXYoOaRs1h3SYXVrg
-        qxg2IQqgGnSnGsdNGVJwSNusOSSF1EE8nUaPDpXStc1Klx1TghQc0rZqDulUORF0tQ7Wg4YPplFN
-        UmwZkjd12645ZC6lDkMEDudgmGhEPaOS0nUlSMEhbafmkLmUOsiFIQiSAuz/EhId0pAhBSndmkPm
-        Urodk9lSl0Yikw9uMqTgkHandEi8KgMh3SIEW4jsQFdjJLK47nERskOviKE8okPa3dIhJcgu+AhA
-        YlIEYaNbOaTL5pAcpOiQdq90SAnS6HaYqUP7u5AbFT2Od2a4EqQ4LdVLhxQg8bCaTn+5FNK1S1MH
-        XUqQ0kzXKB1SktIF68GMGsfxLkswC0i3J0kpOCQEBZDy60qhS5t5D8weAbLr2NUc0rQlKYEfIG/w
-        loIJHgksGo4Xm/QJWiiNRD0YItDVafthvAFxmRF1wElxDqmDxSJP2fAC0lZDunTaCAbZBevBgcK0
-        q4azybOumyKk9NVExQ1mQYZnvSOtWuFRFvPrYUqCcklJWVren6Ys3W/uy8vBGkgO50nKla0zMKdl
-        oSinSags5d1OJ4i4xUAlTXF5HFtuwEUEnN6Z9BNbUtDwZjg268O5nAmJu0U/sZldWcyumbMgjbDp
-        J5azl8Xs6jkbghq7eY4FrLKYPXTAA1xVMbuiDmaw8I8aPjV+Lb+0jjeqfbJnbVTalFRaMympXOwE
-        qVBhMhLF4SyFymAUICflUJiLSg7ZWhQ0lbGgm6PrGiwwlNGBubNWEZjMzUtfLwnKuwTLvc4s2t1v
-        X7TGKxmU1MoXbtg1xQG2J0sejj/CFPee2SHlgrMJMH9DRsSdj+hN2UqGZBs/4kWV8Zpjyi+vpN8y
-        d46L3lLN38SiYsAjs1r5R6kj4xR5cohSvD4nLa86M06jU1fgbnLwPvbrElFUpHldT1XkysswWuxi
-        zOMLQUL64mGrEUF5AaEROI7TyFKeQyzh8Z6Sjy8f/7uRRdp2FPdb8+2oc5zcK4L62zitN3JKW2xv
-        r9MU2vlGTvN9GjLf3U7z3e203t1O6939Kb5karyhndaJdpYeyb7pII2+xxm7YiQD1hdNdYeKcYaH
-        vYvPf3kjXgtUHlyi22StMxi78L/oAXj2+HX17uJ9jUc/w1M+2FQ3heDXBEDi2jbdZv3k4flN+il4
-        ygcc8zmeP6PTAuOQJt8hRAqn7lL2zSFJ+nKGWRVxWyP2/SOAso3CLDongOoqOuHm4mKELW5vLP9e
-        b2F4wbtxi5vDy5LiS1Z5YuF7CMrH4td3LPyriTcg7EjfrnotzdFccBC6pwB98nW4pA1F9RO8qWTN
-        RhWtEt8EquXAG/s5VbYOt/QaQ8JTWXhlorf0FwRfqhRufeeobPFeZBhqCtUpj77w32gjkuPONqQC
-        Yu5xqabNr0IWs5QG2jyR20WpdC2cCjf693O0l5Av/jGaks+jzzOi/jZRr/8Bv1jQY2cJZ+zLn+Dz
-        8HaAX7R3cfLLioB9Pv8AU9x+eSWf4bbZ6ci2aVwMZouFv5zPptCrq1ntPnj6TUvzOf/1RMXt7KzZ
-        wt3CZgMNn1iw6+TVdMXhA/zBTBYr/T8gA6Lsl3gAAA==
+        H4sICF10/2gC/zJ5MjlfdXBkYXRlZC5jaWYAnF1bb+O4kn7PryBwsPAZoKMjURdLmIeGb4m9k9iB
+        nfR0ZzEQFFtJtG1bHsvp7pzF/vet4k2kJMvOTjqOWVX8VCwWi0WK0qySQxLTbzS6+MdFnG4P+3cr
+        WxFJWGaH5JDlW6Tt9tkm2b9rxEN2WKekc5uv0+XbOtmTflJkBXnO96S3eV/n2eryf/rpIflfcpev
+        3zf5fveaFRuro0H8d/623ybrOHl62qc/SOduny8tMk0Oa4v0lsnKIotlZpEHa2H1Giv+yNdvm5Q4
+        dqgxd8lLGj9n++JAnCBya6x1ApzPGvU9Be2p7TgNV8hWcW9xf0vupr1FL9AElvkb2os8LJprTRaL
+        KbFt2r0MPeo1ywwWQxDxbI37lOff493b0zorXtO9oeZu9fQrXkGPPSVFitXv3p5uU+guJ/Ii6vlt
+        osPZBKxkOXbX/Rc2xXIchwa2jZb7x8U6z3dxWT1O3g6v+d5S5WxVZ26TTVqn5vtVBo2rM7IVuFf2
+        nKX7eDYfTIYXwqFIZ5Cv1+kBGJ/If1od4kCbFe8meUm2+c/i+/snAh5AqMncrpK3T+QWGK7OeHxN
+        ck72dPIi32eAh0h94Pk67zpfr4rl6yZbHT6RG+AGOvdqnQN5COSuTh4kxTLLOSM0rpT8TN4TVGEO
+        rEhnjbIi3T6l+xdezbGBqToATXTAIai+Ht53qSoU+2W8ScGcJZ93dFos99kOza0YMAw3MCrjn2n2
+        8now5bdvG9Agzp/jDR+8aWEKpEuzvHnjnWlSn/fJywYIirqC0Z6tiwuH7HDEg/sW71vS6d1+u5lN
+        hqQ/uu+Rnkfu5rP70WQKxqSeFdkRdjn8dBaj69vR9J78cfPl6qr3icxHi8nwYbQgQdi9DCLaAVNR
+        8jM5APA2OYhvTmjZjo+ewX9EJAN9YnTReJlvLFGGMObUmcyRfzeUvBvd3U+GI/CU/t0dfN7dTdgn
+        fNw8jkeT29GcDCeLUW8xIrKiaNUnMhjNR/1574Z86S0GDze9eSkiYQdfeoB1Nx/1vE+8IiJNR18n
+        08sJXOoO/1z8rjUFDdrYDMZALyEd/LpLwQ1W6T9vfuuYItvisIrX2fY7RECyzRuYm3ybY59Vmayv
+        i/TvON9C7EwPYHSw2yoV/XSecLxMti0VDnsYy9iwJu4h2b+kh7iMILyTuaeKzsy3FQvRZgHsbO44
+        zXxwiB1WH8/G1WHJNMK2lVeps2Bo1YkbEUKr9NcU9MhhuDjk5tuCbOEbJTejB/bNBf+5Yd9gxIxH
+        7JuvvgXgiT34VrEDRggYc6anNAlws0PhhEiyPsQFTFhLmFHXyQspks1unbZUeEpfWP+DIXDyOiqX
+        Qn+fkMv3EPwhZYghyvKuX5LOeHY7I4ve3WQ0XXRO1IPORNOzPh8/3PamzfLb5VMGTvYL/Z/ZLArs
+        oFlURDg9Zi9fU3alHQvbZYlH7rLMNMFxhnbUGWIiVWXeNe/gke+bQmeIkN5AklEefaJzcymCAMHh
+        nm1fOuQdvWU6mY4wzA5cMu6SKZlBQA0jy47cC/B2GPbbSxm2LfJn7x5iHEiPKZl1RJC9QN9sxgfO
+        QOIHZOy44gKO61hO171A/z5S89tCr+iTKVyREgfqel3LifwL9PnmusCZfrvR2xYBhCOvHfiWE0YX
+        OI6a6wNHVvT1ig5c2AvKPmZdIoctuCPYP7WS4n3DhnUjV4sRjXz8epQpA0Yjc7t6kiPniMTupAQm
+        ZWeAtOrBMFolmB4ytLfIZNuCTRJHRESY7BEZKDFMUvYNf3vgrlvG5cGTQuh02Tf8Lbk8oLoQTj32
+        DX9LLg+yHoRYHmTxt+Rymg9hN2jg8mAcQHLYZd/YL+OaHiQmmWYHqjCr/lNhG3av8OoOUhHYnRJo
+        cI8GiDYd6s7RpEPFNxpElGv0oV8xTEEvw6qFf2AZf8HWik+RJT50vuqJIn8+/Ez2qYi7qriEZWGB
+        c4zIdBXjR7ovTIqxLlJU1gS5/pmPrm57A7JPn7Ntikky8a3Asu0Qc13n4usQwiGuz0Bi9bZEsA44
+        zGdIW74uBr2bkeAWy2TNYhXyXIiEkCfOye4VVtrbF0b02EI9Xa8ttnyP5fKd09bp9gU6IiGR5Ue2
+        SXwiDrXsboW6JB61qCOpyfZlnUIWAJckkQ0NMOhPMB02kF+SzcakP8Z3wz7xRIlZ6m2b/f0G0L8y
+        Pp3ClLeBxc3+vdoQRS92CaQhL/v8bcez9/HlLencwfqX/+tosnyB8rZex421PmuiqBI4++GAJtUZ
+        k+0hvk+eYHUkVkzE4fskv3aHmrk5ka/OSOfr5T55J6vsGdZIvHelxHL/XhyStYJ0FWIsWJbI7w0a
+        5L4FxoNNmqC5jnBvk8PhNf1ZEMeCOfeI0C6FbG6Lad2aKM01KbWWJNPZdFRTD035UzYjbtCVCwhL
+        fG5kHtLNroUVl2lWk8huTELLb2ax+WMcQ1yBZc7n4zJyqdrp9Z3gEtznaja/JZPJhAzm3xb3vZsF
+        +RPWcWTWv+9BijAkvStMiO4h7stl6p+9BS4CF7ObL8CfTEXO1LuHeeL2+l+3MLtMh+R28hW4f07u
+        x8S26C2sBW9n08kDfBnASvMeFoO25ZBbcj+fLEj/4eoKIO5YA1l11/4PMlnMYI1415vObqwO9gfz
+        q63wE1FINk+YJMfMtA4OvAaGbljBNjpSYaNgujzke0uU9WtpTPGFDAbDOpevSm9789vZojcZEEp9
+        stmgbKcuzHpliVtBbLzg5lVaqmlcUmXgkrlPVhnf92rStuT+TH6kIswdkeC7HbAQWL7u8w3QlhDR
+        43UCgWoTr8ltQxVNOt9rGldABXW3zw85NJN0FhnGSlLq1DlWFSYBXEeDfMxM+guDS1Pz4xLMam6g
+        LlF+BRcMuzSwT8gfIKzY2nX5urDR5oLF/5DF+xYtdNjjLGpKcB8ZLeZXpD/q3bJ0fDKk7iXtVEXl
+        ukhCxRDNUoJVT0o+pckG5tFUQDfKt5ijWSxeZ2wfGQwC0/x6Wxgdzc2hM0RqoJErU4ig5k9Fuv+R
+        riBqZdjtrKUvmySeEBfsf1LsCp1QCK3gC8T5N9aX6/wn5EVsUm5iv8ISklDLLdlyn/CpIDQIquRk
+        vdauJGeVXQ5ZFMyZrFbkWa5phDksL1/SeMLYEPmiChtT4h/J+i3VoVlumB6gEuRivJUTyKeiUtN+
+        nBV5/CcEBmhIWhyyDYYP17Mc1zNxMN/arpLt8h2sGZWdFxevKjVp6EKdXetIwWTWrJvR4LI+sLwq
+        s2Y9NC4szv2KXMV8Pm3Sr8mIgg/pw7Y0I4dxtV7QYQxLOcJSMIgkF7+jjRqTHSFa93AFUDWyYtzf
+        LNBU2eoNpqXe8I5vPH1WQip3kjoz//Sd4wKlp6qLgIwcVMc4V7BqMDXGm2XLt0P+/Mx6OU6eiqtq
+        dV0IOvukDAPab4qqIKiheYwatQbLdDXBkq6kGQeHoWGeefyc4Gwq3IhCsIsa+abldM48/pnvv7PK
+        nmMfEXnepymKBLbttojE6X7P584TInr+crTF4rK+5R73CCHjeA0iu2QPywQIqcURp8Nla7Y96Ox8
+        uXzb4VCJN9m2mZ780ujLfL9P13yKXeYp+MFVHh/y+GoJ5oq0Dj0uKI0b+aGS5mEQBzkkW1bgl83D
+        DdE87v+X8xf8I5eOY3l+jUn/gn8EeKFd47l/wT9yaVtuIyjUM3xUY7lHWLTOgrnoB/bkBlb8a9XZ
+        t73FH0dEWF/F33Ep87lV5MkU4RmCkPux+ol52VPK8p4MshxqN0tiL+iStm4pQ7J43fN7LUclwaOW
+        ewj3GKmzlbivBwuM+ezhejx7uFfS0gyd8bfhfHY9mi7IuPdlBPnSaEp6wyFffODKZD4ZTqbX5G62
+        mNxPZtOF1akod0j2uMrllqmag2uAzoXJ9n6D4R1c/W15gCR+djPi97Lmo7sbWLrgCqiCDr0KydYO
+        UmZYg+43ELwbL1MAdprjDg+kTzA5iLs7bL4qcLnwdXILy6ObyR+jm8l4Nht2jtXXqsIqP13Gy6RI
+        q5ebx1cYPopULSyEOeewvJrdmsI4MULIi0eLh3iO6YnntAgwZHTgoJSSAsCHBSDwqt0uBXAPpx74
+        tOp9mHV9z21izePB/i1bfi9ek+33eHhXm8MMWRY+P1Khj/PWWaiapEoPYFYqDh/IEbj88n25ZpI3
+        vcV9A5TMOQ85TJW4iEohzor0p0Vy+waw4JHJEqDtU9Lr7CXZ1uQMETG+CW2ROeSwoCZl8OUiR6Zs
+        nVlO9Wq3UghBsGDzjrirVKWu0h94exTPXRxlidFSl5AnBKp03qY63ezao3wxS8bPb1vW4RedffyU
+        b1dCfhWvOjg+qCs+PxPfbfIT8C1ZM8fAgvXErf7j4nwfUl0pfelAVPedCD6jsAs1u/apyuJiWPXk
+        5VbZa7ra40EmVtXh1XxYfQTwads2tu7s6lQo7FldGnKHQAB6NoArACKLYpOlBtHZAN6Z7V6+ZliJ
+        dTb2pkO7mO6xq4XHq72kMI2uk21ayC5irmBHzBWwsntebdZHZ+i5fVqVVzpL+nxkzFE/gs3S7jPR
+        f72/Msf/mP56rXOvBJM/bgLC/Hj+dco6515Fbq2zlOv8CxnVPnytVz3qfLzih6/3/zFlQ+Wze27J
+        1MwO58ueD83DwZnYWtw8p8kf0Lv4mN7FR/QuPqj3OocEmt1fiPsf6GGj2rnX2mcvsDQQ/sti7Onm
+        7AA6W+KNHkzRPlYDr3S6Nf/Q53xjw+icdM+sw3Il7UDiE97wfSvwVKtdr1LJoZxjEnyXzQ0aIKr7
+        AGwXgwZ1wYadjm6DWMN2i2Pri9pGRLF2D0L3pFh1jXD00gL18+k2872PU3LG3k+DepyPN27ZIrF2
+        25ZTxSnxBSu97VOSP5MiZedGxXlA8rzPNwRGBEnEsXF2W1ke1/ln7+kT4fuBsD5kN+t++0SSNSwD
+        t7jJu5OHy/HuXUddV9zJ0fcRPpvMQW9R7i3Wa2GmHRt3m7hM/D19B4dYFc0NLtkMS5ZIR5wPJVeT
+        /nxy06nLH9Jfh6pYw4HTjnaUgSPgORJ2+Ewv88N4a1zv3Q37kKlBMp7Jw2c1QWgynqysYGhnUHSy
+        vHfaI1P4wfPaffaNGmYCvxE3oTTC6omfxnuY3lXp7Ehpz4vFQT2NaRxm1OhHD6Z+roslsLbD+0Av
+        fHuuyobrJ8tlWuBBD3Jn+3bQbRTKihyP3FUbyk5z8ktUtWQs/NvIYLjYP9A1THXDlQwp44xsRQCN
+        oFp47DKGkDpYY1qjgpbCajg4hYYnOVvQzrEvE0QZ1YYg7B5HOqcRSo61IaIn0M5phDoVVapJz5JE
+        FbrqqK4aSkW6eVq/W9oJ3CpLhh/+DEWM/S+PG0Fo4otbKXwEQuzqSaS7yaJ3RDIHXfEAeLZU0uJI
+        eLY8XYU9DsOPEDSJ4qrNUoXjTWZyOcxseHJjLxzGacVkh+j4zdjep35VAYaFzAY7lzx+G5qfMD+8
+        E2QkIm1prsCimBP7vn9MQqX0Coz8+vT+6d/H5DfJYZ/9Ehv0Di7ZxX+nK4jN9/MruOdV+MGOXKA+
+        H4Cnf328Av1Qi+lHG/Ax+7gfbYD718ev4J7XYtGAanPLyecpy8WBMe1JAHA6MYKrOUqDBJ4jh7G7
+        0tOkBjHxEEC7kDjAuUn3p9DSv9/SbYl38TukPF8mX2ak6TkcyAH7v5EJHvVl6dHs5tv9ZIDfhw+D
+        ezK7usC7H+WDOKPBw3wxm8tHcqD63d1vFun11dktSCN58gnZ5MVgNp+PFnez6XBB7me1x44AH5/9
+        ufi9sSWvidw3xuVLtsW7E+JYSPUBAbY9LJ8wqdHxo4nO8lAIJk/5usbjk408qVR5sEAT4fdMgLp9
+        zo6IyIOreHZ5Kn4cVhrAPygsYLJjRVaaEpeVZvCDJY/z+oLpc+bXe8EOWHkMP1jq8hIVxZAXe6IY
+        8WLfEWXHFgQp7ziC4EoC12wMlxME/kiDVM7xWHGsEH1eVoABe7JBNbvLiqrdTsjLom1OxIoSHNap
+        jCubDg7FyteyTHl56EiCKwhUEjwOqKxF+ZMW0lyUq6fUpVw/ZTDK9SsNRCNBkAZyuY7ja1nmOo6H
+        jjSJSyVFgriupCgUT1CoquVLiqoVSIqqJbRVneOG7GkQaW03YkVlbc/mZWEcz2FF5WeUc6W1Pf5o
+        ibK25/HyUJZ9Xh7JcsAv/iiu7nU5vLK9x7WTtve4dsr2PtdO2d7n6pW296kgyPb7XMPxtZLwBEFJ
+        cB3BZpIQCIKS4FqOR0pCaDlSEkLPR9k1gVD0UVYJhKaPskogNFUdE7jsURvZMYHHiqpjAv4kjuyY
+        IGBF2TGQ0DOu7Jgg5GXsmG9YjniZDQMkdG1BoJLgcMJISVBBUBJcwcGjLHMNy87rchVVnOEqqs7r
+        ch1V53W5jmXndSNBkDYKuZIwCCTBEQQVvLiS45GScAVBSXAtx4+yLJRUdg8D9oiStDusfLCo7B6G
+        vCwMKx5oknaPbM6Vdo8cXr6W4QaWPpwgw03kcgBltchjBGm1yOdFqX/E1SvjM9dv3Jdlrt/4WgWT
+        KJIUFWFtW5JU0LYdQaJlpKeSVFZ0JamsKPQtw73tN023uJvZNN0yuphuY+coh9Y47IwCzpR4W7TC
+        a5+KS5GjU3EpYk7F4AcLPNVRTshTaLYiUUmiJc0t521F8xStXxJ9SRxrFwnEND8jw9lDX5uwB8xn
+        lFwop3ycqhU1KqmaRmIOZ2RXIzsqTxjr0DCh8/l77OiNFzSqt55P3KaROG1cFzONpCZ5zUiSZhhJ
+        EE0j8ZTAMJIgmUaSycG1biNBrNpIkU0byXxi6BgmUmQdxJXksXZBx1M5CJvzS4avM3ScQGfo6nRV
+        9sISgZIR6gwdKtIZGpTInGq9Tx2RIFR6ldHMXuUks1dlMqH3qqCZvcqJlV5lqYfZq5xU6VWRhJi9
+        yom1XpXkSq+KvGVodiqnYrpgdKoku2avilxnZHYpp46HlQ6V5Ep38vwIUiKjLzkVpzGjJyW50o88
+        p8L0o9aNjywJKcm0JOsgrkrETGfwRFJiOgOnGc4gSIYzqARGcwZJM5xBEE1n4OmO4QyCZDqDTHwM
+        ZxDEqjMosukMMleC8cau9o17gyILkG/cG1QmNXI0uqfo46E5xlWiBb1ZwgeKbnpKt8zDHjXxUJHH
+        I8dwCpWlPZbaUFuRDR+ijszhxo+GU8hMzux9V6RGZu9zmtH7gmT0vkqjtN6XNKP3BdHsfZ50Gb0v
+        SGbvy/Tr2pgFFdXsfkEe943elxkby6H0aKAxzHigMcyIIHM9llbpPqAxzLCgMczAILNEc2rG9wWx
+        fQP2/E1th0njsHu/Md62KJ5jY3sTX0TkUcjWzxDXttbOEXc/IG5uVZ4jzpUJaeifJf4RZdyPKeN+
+        zDKuVIa6ASwRjorXtnxPitLzRUtzlOk6q4J7XJbY4xpcTC9mFT5CWvwR3rthXydiZl+WjL2ykrxO
+        ntJ1rDbYaoz1oZGulg61CvLB/SpDu2FaZcn3PZT08t6fev1ByRwk+8M2/lUnvddJ/9ZJ6okDncif
+        C8j3cfr3W/ajpgTe0kzWeI94/2Jooe5jmZozcoN1GL3BOJxeN7+yAL/jzl42UOFy42XbVfqrxiuy
+        50MR/8I7b+K+8gmRZLk8BdKggimxT4uL3v3sljgsHFriFRQOe4nVpWu5QZf4Vtd2SdeKPJvt8kMS
+        YzkOO8LJpadM/mF6J+6F4lYz+YPj4jJ90KsDR12XBFbo+ATfiuIKYLiUrwEPei3ILttDqACDZiEF
+        YI/aqLcTCmBqeQZwC67HNiMquL5FfQ8f0utS+PRsT+EGroY7a8H1Ud9+3RIUwELLcdHEbiAUdgOL
+        hrrC/RbkAJGv68i+7wJyFATwGQTCxi5eRUe+bkHuIvKwbmQf9cQDshFAu2HAoT3XCqkOPWyBDhF6
+        1AAdUXxmh8K0Hlk+vk6NaQ0WMuwxaoGO0Jcf610YBjZ/SYSH0I5XGsTw5scWaMeW44S9jMVhL2oD
+        UzvdELzOdwLiWaEn3dm2PDS1K6SnTN4ADsmNAHbUQDGRXYZMA5+4lud0ObITWF0dedBrg6ZypOjI
+        FMwRgbaR1yXUiqhE9nkfKuQ2YFcOFR3YAV+jABxENj7hCyOcA3sWOHoJPGsD9tRYMVXuepSNEgoq
+        +4FwOyeEwamr3G+D9tVgqVija2MoAmgA9XzVg6Y1rtug2TiEtUoFGx9XDFBtuIINPuKWajs69tBp
+        A+dDkdatHYY2DELbs9mZPioUh6FogtM28FB4NX+JEL5ciPleF6IxPnSM5nb9oOxIfObAE9JTJm8A
+        R+SLAI6kV1eQXRiD4HU2YgZBpJB9T0Me9FqgIcBzr64gRx5q24V+tvFMpRovDtWR24Ad4dUGsG85
+        HqrshRF7MsAvOzHUgGdtwFR6dUXlIKTMDDbidx1lDNfWVe63QbPJ8NqpYzvgBjabDuEKUVdhQ+TW
+        sK+dNnA2Gq9pHdy2EbDrY2wKbTF1OS7PDkpw2gbuC9fj76DCN1dxaJi7oBsjBx/SDLrS9yKItOzp
+        Ey4+ZRV0ZAg6VwI5kL5XgfZsn+C87eOwt8NyOIaBBj3otWF3hfMZ0KCvj2guCEIhiMoA5VMdug05
+        FN5nIDswMNBHnJAp7XulPaiOPGtDjqT7VZSOoDeg/6D1bFJwFXTX1ZXut2C7toyqFVtTaA/GkS4L
+        g55Xqm1gX7dhOyqsVhT3bDZ1QcLAhqetwH1bB2dx9Sg6VXHVQIcRAiHKg/FIsRBp6N3IQKdt6Gxc
+        jhp0D6ALwdowOi8xb6BqvnENTxm16s4G5qhBdx9GoMeSd0Cn3ajU3TPQW3VnM+VjvU/RrzG5jMhl
+        F6YCqsBtY/w8tmEHlVHvy4wVo6sfeWyO0MaPgzYPtFHvm8iOQu5WR72AdmBGwFBiM1d0qAizFIar
+        r2EPem3gYWXYC+wQptJLfCbaRk/0ZMpD0Yl07DboqDLufT7r2JCQwPCnPnPycuHh8JVSoA38Y9Ce
+        XR34vlx5hIgdQQzGUrfE9nVzs5F/FNypjnyfO7gLMQHjOIQdtJDtq8SEGuDXbeC0NvQZug06sxAb
+        dZnqgUeVxbtUR2dj/yi8Wxv7fpkMgpfY4IE4mtxuudzzDHjaBu/VBr/Q3sZpDVIV9HPwxchR2geB
+        Dj9q1d6vjX6hvQ36YkSE7Ac9SMLj8HcM+Fbtg+rwF8oHXcodM2SBkWph10B/bAPvivHP3y2J75wU
+        04WLl/DBWzAsumW3Bogt3kfJAkBgQlPSE9ChDAAV7BDGImBjZghxK1QBIOBLeIk96LWBRyIAVLAd
+        WCGykQSmCSFHFP6Cb4sNdOwWaJizeAAwoPEBX5v9CRh0oFYmYG4detYG7cgAUFE7AAfEFYnNoGUa
+        DtBBpGvdb8OmqPbX+wZ7e3yIwhIe0EPfUyt56umKQ91G+DG+UO4WH6PmdsHb5fhaTIsHxggnNwgz
+        zDwwbTrSD7sQFXA5L1+pKZaaWJTvVJfQXhN0wBbw4NohuB/OcNRTduHbG/JlnApZf1u7/oZUvtf2
+        tt3F4hmhovYi1AYR80WqDQJYYJt/xwTEl1aQbFscEjyzeupK7DUb7SLpdtWmDG64noIRUq1IT2lx
+        iDfJbpdtX1oaJo69Xzh4wJZ7FMZR3MVBz0Jne2fvfisFLtF7MF7BmPIDJk22NRmH40C4CHD/q0nG
+        5TAwrvwoahbxOAqkfAFu5zSJ+EIELuQcuVDARVz8DZpFRLMhsAS+3ywSihaFJOi6zSKREIlAxNNE
+        mjxd7CofcXLJbfJvyRNuoP6/G0dFGlnGG3qbWNVnqxpF0ZtwX/wYr3yLcJ1XHZY678io1EWODUop
+        g0+D8ndmNDDlK/Sa2/96DNO849AicKxt/G++SbLtaZATRpBiuiEcUr4r+w/4wYGsjevPOJrVM76f
+        hTh/efYN/OA+10lx/jbtL/CDexMnxfnrta/gBxc1J8V9Tdw5LR6IqbHH4lWL+D8u/g8AAP//AwCW
+        uC+I8mgAAA==
     headers:
       Accept-Ranges:
       - bytes
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Headers:
+      - DNT,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Range,Authorization
+      Access-Control-Allow-Methods:
+      - GET, PUT, POST, DELETE, PATCH, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
+      Access-Control-Max-Age:
+      - '1728000'
+      Cache-Control:
+      - max-age=60, private
       Connection:
-      - Keep-Alive
+      - keep-alive
       Content-Disposition:
       - attachment
-      Content-Encoding:
-      - gzip
       Content-Length:
-      - '7920'
+      - '7474'
       Content-Type:
-      - application/x-gzip
+      - application/octet-stream
       Date:
-      - Mon, 18 Aug 2025 18:16:51 GMT
+      - Tue, 23 Jun 2026 10:40:14 GMT
       Etag:
-      - '"ff7638fce-1ed9-54db934856840"'
+      - '"68ff745d-1d32"'
       Last-Modified:
-      - Sat, 22 Apr 2017 03:45:29 GMT
-      Server:
-      - Apache/2.2.15 (Red Hat)
+      - Mon, 27 Oct 2025 13:32:13 GMT
       Strict-Transport-Security:
       - max-age=0
-      Vary:
-      - Accept-Encoding
     status:
       code: 200
       message: OK

--- a/tests/pdbe/cassettes/test_fetch/test_fetch_archived.yaml
+++ b/tests/pdbe/cassettes/test_fetch/test_fetch_archived.yaml
@@ -1,0 +1,185 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept-Encoding:
+      - gzip
+    method: GET
+    uri: https://www.ebi.ac.uk/pdbe/entry-files/download/2y29.cif.gz
+  response:
+    body:
+      string: !!binary |
+        H4sICNnR+lgC/zJ5MjkuY2lmAMVd62/jOJL/nr+CwOLg6UNbrbft3Q+BbCuJZ/xa2+nu9GIgKLaS
+        6Ma2vJLT3bnD/e9XRepBUpSdZAa49OzGEat+LBarisWH6E14DAPzzuxd/I1cBNH+mL5o8YYQgs8I
+        fRg+b+JjsE72D0m60zbx+hjsw11E2M9ut44fgsPm/icWqcm/R2kWJ3skdzSz01NTbZN1eGRkT8fj
+        4e+fPlFsDbC1JH38hERQHKZxlH0Ks3Ucf5IrB3G3SXIILoINtOs+zKLA1MqP0C51wTrZRORiPuwX
+        7S5+8JlPiN8ftW23Yxr02ZcvSDkMDLOn6+wxVzEKU1WSRtvwGG20zT3T2YlyKp26FNR0hK4Jji+H
+        ExDRMYy3GWuHcTvzyPM+O0SgoDjakJZ3tfIXxJouWznFyvsiUvRnn0dTn6wWd/PlaEoGs8l87H/1
+        h2Q1I958PsoZzTvrV5FxuVrcDla3C5/MrsjSv5740xXxRqPr8YRcLWYTsrrxiTe5G89Gw3bfX3lk
+        7s9Xo6FPfvH6H8nCX46Gt/6SWHrbcj6U8v02Faq5aC1n49vVaDYlQoUDkG34nx+JNyWj6dCf+/B/
+        09X4jlzNxkN/6H9dLbyBPx7fjr0FGc4mHrQN2G5uJ8AhSrXwB7eL5WwxX8xW/mhaSPLPwUTSJeMi
+        YltMB8X/SKaTxUdi6pWUpcr7nis26R/qJqG+Jv7qBgqgR9qzr6Ph6Bt0BF9vu6zXaNv6Bw2aBipE
+        Uo8CeldX/mAFvTi9mi0m9Jk3Jssvo9XgZjS9vmRiGryYF//I23u3kjpYKeXVwmNdnbccn1GN5GIW
+        AoK+l8MlmYywF6APCrRSK7/2G6oDEcUqeQX8yzfc3znrMdpmFxpk1/UOFjt+hcVOPl9ff/488t5m
+        s07bNqHTvTG419Rb+WQ+G99NwIZuiFnWb3qvqP+38eerq7fVbrht02ionfPX3/4/Wm8U/TvwdGWg
+        GdwA5bloA4GsqwpkZhXI+ouBQKGV3mZL3oatUttys2eRD2jAHvkCrVu0mRH7xJ9+Hi1mU9ScRkbL
+        3GMn/YUH/kqWc28KnntdhJsvNz5U8wViK7jeb2S0ApZTDuh5c1WLzC+/WaIuBou75Qrdmm8Li2yj
+        6fJ2PJq2h/71whuiMP70292EumOubALB4EbsZmyyWYbgf34R5WihQ3oQR+6W0Gaoijp+FQikAFAY
+        TQH31TBEOHwwX/VzNRVk3/ye1G/fRtNBuw/RndMpdtr4240/mviL1pIMR0vfW/rqjqyMi7WYICD5
+        ZTT6AKMHGkMZ+b4O6g2uheayvaz5Da0GGU39U1cnn//+mdz4X72r8e1sMRstZzC8gIHMxp+oTUFg
+        /IroRfNHUvQ9NUi8WgOsX4tmfvM7f7GG0chpY0pZvRWBIOBqTl6p2fevpUqtoeSEXG0ewjOpydWo
+        vxiNS++4nY1UEcGuIoI36UtVvV5RVWwlbWJ2P5BfqJ9ORtPRhA3Cn33of78SvVTr4os4vLfyHGM+
+        BwuEJopmfjsTO6E1mY0h/6BZyt3Ug0izJMvRBB5QfUpBiqBqyC8EoP5ObeZD2QdFBbMvNUN6i/3I
+        2RC0YT4HPYtWUoasyVgRbE/hQ3RWKh2SmQp08Ff3o8OF2w+lac7tv94fVld+m/nEL129beofSt8o
+        3fDXoVStMp6jIiFMQdRdjQacMIOZd51bx5U3WM0W5OuoFt1/u52OVt8I7UOUdjS9GfVHSMyAAKcs
+        m/pfgX00KtUym0jyTWZDf3xGEe3lsuzYPjwfEowGBNKD0nRyiyr00P918K4E8EqZADqKxHtSG8ja
+        0DHg06DrSqFc0lNZP5EmAzffrNfbpJQ7VaLqbcid0P7+VpvPZcfw+Jxp7Bebmqp+FtARDax0Fh/Q
+        Wbzyh03t1byb6JBkMDOH/ynrpRPiBt5DmqyjLHsX7/KaLT40yaw1MabR+vsmiPfxMQ63QS5+nOyR
+        EKUwdVC2YbZhYtAkNky+cRUixPWI3SE8xvdbXv67V3RRkD3UZb58DeMufSfjOnsD4y46PiWbDPTz
+        Pdomhx2uJqxBQY8JU/klv4TB1mbCZ2BJtXzZQnhGq0jSTbwPtzAvHyTbbXSMo/Qj+VVrEYi4F61x
+        +Bjukx/ZHy8wO4CHJs7fwx/hSwhjqbZAMmLBMz/Oov19lD5+JEN8aLM1p3V8pGtBWrMVH9J4F4L0
+        HPExPm7V3tKaJNto/bwNU9IPszgj0OHE271sk3jT/p9+dAz/l8yT7csuSQ9PcbYDUTjc/0qeU2hq
+        EN7fp9F3waTB5LVpeNxq3jrcaMt1rN0uPRXv92T7vBOEM/QuT3gIH6PgIU6zoyy84fasOuk2rFNS
+        AyjJXqIwbYgAOmTeCiHjTeAtVxO+gVNv6bk87Tp5bnDU22UD5mi5nHJ0um522l3btBvIB8shEchh
+        FsZR3ifJH8Hh+X4bZ09R2th60Q8Adv58P4no0qbRs3um7ZykHkKWmXeTZugd6xNqQjMMw3R1nXZd
+        5TAFSuEf5d90TU8uzT1Kflz6U2HYNb8Cx+JKZQ8DFxNK95vwGX2txZph8aXfnsKEK0O340qXSRoD
+        OML2KYnDl14n2022ftrFm+NHMoZyly+92ibH3JXZT4cvHeCybcKVd4V6pfhAenypHClw6sxiRbTd
+        qsa8fJijxdto/3h8CkKuuKc5PV0qv+e9ztT0jkyw5ghsUzONkiDcP26jINwenspKerqmS+X3EGnI
+        ifLHcLdT838L2Po0L0BRRo33eR//+xkk+BlnZUAPspcdhP705WxOUGirZMgO4RrkSZPnA126Dm7a
+        EzGkzsGR2H8tnpEK8/C83QYNEJc8NcofZNHxGO8flXIJ1CMYtlYhDM9ZsH/e3Ue18Gb0eL+ERsdH
+        up9Rfs6X0PO/snQdsKGxesYiQZSt0/hAtyPKEkwSYAgJfkTx49NR4mDyBMlDsGNDTZRJFNFaerB7
+        ZhFAevyQho84QFePy6V9gxxwkIJ2Zy97aR0a51NFqtoxba2n9yBgXMK/lrjCyKXMbrfTdntmC7Vs
+        kh+QEKBG9+Gx/Fz/MbqaDkk2hJtL+u/sT26KrC3MECDP0vK/qUkainJujwmTbMWSOwSo/nz+kS4X
+        0v//WM1LFNNZqpuPZOAv/P4CEv/P3pJNt6WFGyD57AEWTAE8+6M0PWqPoKo5/sqT91xs7BehSSrN
+        SeTUFpt/Wkh0iMAIN9EvY1yUE7j32XETbOP9H5AMKLj3iYp+l+yTnbJja/TUFrPo30Gyh2QDPBSs
+        m5uN5KvVr+OBXHN/mueYwoCl0pyS/Bimj9ERyLEEpmGpZGyC/1M+lIrrn3oZ+K/i6a4YxOWCpwja
+        lqBHGmR8tyR7/GiSsX/LPlpgXmP2EfwSJpb0o1N9dMFWPfxYzgDzKjAmgXc3GZPRQM7UCH+IDCfJ
+        wy1M9CDvgij9sA0x/mbh7rCNTvHcR4+0h1Ff0qRDRR5Br76OPEkhn4HUO4AUgXUrHWxbN7PJjCy9
+        +cinC3yneSFwYJflsYOtv6lZ9uv7GOzoJzoEp+Weq7sNHEUUVoc3sODn9TFIo4cTcxbaHRxlsS2s
+        Sqan8xpt02KAZwdFUzmGE9FIEuOEq18qKMNt/LhHQ4j38kAtUYLM4RrXBPLd/3xOoTu621GTx1mC
+        w+xJBVMHZEKcCrUSA/5u7hkFAxUJki6cDdQ1X+RLCp7GYObVGVDrpT5fLZXAFcT7TN1dUg3gi7Ua
+        3LM1oAefruFEV6t7m3IhQ2PDMTM5UZGq6SrJSlpV0wlkPufqkBrf2HqcwwWqvjRfx1DJ1xEmlk8R
+        jWkHlsNWf+ZpbPWARj0c4Wkg50uK6Wb5gPXvyz7Zv+wyoSRPcFXPyqQXR63WuJ3nJQQTEEjdW+QF
+        xzM8rlB6bWtgkZsOmZKZyWZ73Z6m93AeejO7gXxj3y6S2WqRjy2YV57fujHJrKXIPi9wpFXLASUD
+        UQ6X3BhWJYhhGZrRsQADBu4GjLtlBVFiOGQK4pi4tW3YHc3oOeQCB3Q1BpRM78aFVhCjBxgGJ4fr
+        aEYXogimCmoMKJHkcCQMA+Sw3TzF/nk4qqbCeaxixfl8h080v7YX3h1kzFdXC2+QH83IqdfpS3YM
+        t9x8y+LqCvLihiHPqNFBwpbhoLSLwkwcOtR0k/B4fIp+5LSGhr3WQHqIII/ZY0KzxSb3FITVnK76
+        mc5Av/UW4bT1R9H6UpmGmkxW6aWa7BjtDvLUtoEs4JKNBrLDjajsruY0EKK/H24CGJQeoxN4bN5b
+        Vgtzrj49X0LwABEZjUYk355aki94nmHWX3lgnEPC9l/p4Yp8ovnFo1shy9n4M5SXm8PeCjLgyfWn
+        yZh40yFufBdb8rpmTmAeNplNR7fwYQCzvBVMxHTNIBOyWoyWpH97dQUQ8xvaUGS39P8g3G66lk/I
+        NvHDQ9q4cGxUFOHuPqan6sRuMeiai4KGU85lRSGbSFVPJQxyRutjkmr536qkvkaaf5AaMBgMFcQN
+        U8nWxFtMZktvNCCm6ZDdDtlbCn7a+Wtcb1zzmyeXarlOpME5dRpuYraw2tBiZdsrrh/h9yhfcmsO
+        LTUutqoCGf36KU128GwdJGmwDZ+jYBdgVJiouDiGJG1aglLXlT89pMkxWdO4w+keRpDrsQ+m/9kf
+        +9Pr1U2rESdbh5h0Q9APaj35s52GL2rlBpWaRHs3zhBXH3F9Xet2TFc/x8JvNhiaLkjEJpEn+9qo
+        UbNfaqNY3k0HN4vZajGb1vhOLZu0/OUCj+N4Ezpujoam1TZbNYgiBcJuP6bQUG7LkiKcZbiPwh2M
+        08jEKlGzCIrmtjRklat5gm1c7fHkDgZZ5HafCeZX07ch0RVbC6SZ7uT6cJ4/5KTJfRal3yOYFKUx
+        Gi1V3+MuDHDDxELLOEt5lXtVTreBDzBsP1Ob2yY/pL0qtgquon2CnFSg1SyOtFiSvc9UbXLdGmW4
+        3Ta4f6HNPMc4JDDPud9GAnbP1ixJ8QvIbh+jYCTLAONaTybNXnbB93D7HDXXTteZoyPAfQdpqSpH
+        BZ2j9bim93EiHXyBOA1airJjvAurPXnL1gzLlnDTaPO834T7tbSzZ2k93vCC7Knccaibn6Gkq5tf
+        jY72aq07xf4USGUrAVK7RlrrLtbBMA9xZNKGntI1x1S2qd5dlzId5Lj7qqtKZIvvex6y3gNAWuoe
+        Yk1Bhp9PbeU0ZfQ5ytmtoLrbl5WfHc2rzi15VuMldlm8eYY0yRvOi7VGhZUjTznXKFSk9l8QzzFO
+        cKl9WaiJSrfNuOjVvIOh5rlq5tFkzeGLNuvnY/LwQO08CO+zqzP18Dxg8CqWkzy0nnSXyYyithsc
+        qnZkoAzDAl/NZ2W+0oVztsIpT/cuBlOxexfBQ4gJaKM95A5rwsDaU3M22YRCKSXPIviRpH+cqM02
+        9CbOhzSKmjldXbdOcQZRmioS0svzPIGco1+e6oEGOR3NOuFeTY0zbBXTIUzDHe6YZK9QfVkRrqPG
+        ++NZnmS9fj5g3Ax28f7MTqSCJ/z5Sp51ktKXrTDzWCcRONhVEhyT4Gpd69web/TNfJISgc/pVnxs
+        EMdh5FygNjXX4RSPeyFJ0P+X8Tv8d4qxbRia7dQZzd/hv1OMwNfV63zW7/DfyQp1zVILero+Mfhw
+        bNY72My3sUG2+R3dZZdsom3QMP3Fn4m3/K2JjXpA8EeWbE9ZmIrn/gwPm5rkjN83P3A2eh/RSVws
+        9plm6g1saJlNbLrQ0wJb9pSy/efXsYFvr1NIxTBvijdBfSESflYw67u9vpndrirmEyqX0p6bu+Fi
+        du1Pl+QGZt0wD/SnxBsO2RoULlAtRuwA8mw5wqxoqbXkph3DFM+isC54XTrAGoIejYsk6Q7TM7bm
+        z6/ElKf7F/587A18XCiTawf7hNnlIV4HxycAgnypLkat66HKKMEFe5gsQmKX743T3DSr1oG+jia3
+        EzIe/eaPRzez2bDVCMMhBHjOOViHWaSsehFc4ZiTReWyUb2nFt50OJtIjJgUw2Ac+MvbYNHohIZt
+        nOKjlSud1+X4ChbgmIzPOH3NYgvmwxOeCjw7HnN19U8aqqU5tqXkWwSD9Dle/5E9hfs/guF8dLLv
+        BUY6/te5T/L0Ma2Ua3lNPXXGS36qAmlhdjw/Xzk1T2EQ65f19uRkZ+wtV6pqiyn9MYH8Fxfooio3
+        KOZ0Jzj2z1Av+GG4pnXrZxm28WPIbTLKDAJtHj/FMfwUwzE51pZvuAGfcZzNx4VUnOc5kfvnaX+1
+        JZlzQyynCVqxEyk/3kTf8XgOnmdtLssjjYKkPGInF+TbUPUCydYaCfKkMnh43q/Z4bs0uE/2m5x+
+        E2zkqGBa5a9L4lhKo70sYRKM3MGm5lDir0vSDMNOgpbi8LvjhuYYPfzV63YQpqOfg8nFEbfY3yLN
+        Jn6KNikefqd4BoflaIbl4i8dTAR183oYk4MxbK1jdpml6UBtvh7G4mF6mgnKMZwcpvd6GJuDeYtu
+        1k8xglCjqo9eZodO85huuidgHiPIvrbhPsqKXhcy0R4zPwpjdV8FQ3v9nR2+v9/UxHgnjCzGu2Bw
+        cquU5+0wSnneAvPz5Yk6uUJH74WRZHoLDOSduPEIeVdNP++DqennLTDFIW06BxEFejeMKNC7YJ74
+        4P5nYXh53gVT77I/CVNI9KYOX9PGxMc/55o5jMqp3gbDgnB8/JPScAPe+2Gyv0Y32V+jm+yv0U32
+        1+hmm8C8mJ4iCfp/wsMFmPd7eBo/xpsidRMH4Dfp5gACxGs8QSSvaL4TBkV6Xyz+m5C2CltD75xD
+        iTB0GsG9qXKPRxufM/ZSnK7getWUwmhkPDWv0CxXVaO8ylxbfDddBdfZ1XrIwzoqxrObEYYuLAYq
+        q3xoWIdwu9Z5xvqqwuV5ORcKWz2vy5qcxlkmxY7J5ak2ndh1q85wn9iBFE5Vn3if96K1pCTPaUSS
+        B5JF7I2p/AWThzTZEQgsJMzf8KWv3RXHK3/x7j8StiEZZeUVSuH2GKV73CU/FO8B45m3ViWN8GKY
+        0GXNL2KJzMoV5EuJaOAt61ukl0oknHuLp9K4g/J/RC/gC5v60Q7x5HpJRnGLv+j7ffm9H+z6lZaC
+        5Rj9PIqvBAositexWvxSQg4XQlrDzjfzD9jLJltcx8Iz+OsnmLXH5fHmGiUoJL+PQSjj3/jhn5dv
+        1HlkCv/wPbmLPv1oSmq8j5P8eGtxpK94SRjF2oXHNP7ZfORWRZzAyPVT2JsxcMqqs3OHpxjKPRL9
+        lQzWmxhMTqTXMphvaoP5VpGst4pkvVVL/JbVa9oQfKfHIJlYeQ2voTffSG8J9PQezmOyowfVTp/W
+        yi2Po35IITgH+FJK9pDXVZofvtxumx3nVRx8G/RXcVhv4zB/F/T6Oo5Cqq7ZdV7H8UaprDdLZb1Z
+        V1YllWm5PeMEB2+Agk2dYTDfymDJDNwVIciJw48G0fQ+2ZKLAbmYkotZjQjhNfYOOL7Azj+lUbn6
+        k45mBRz3fBvew1hH/5Y48pLtUV2A7680sODpLWUJP2DIZfi6jlRQvSNWvCTElw7C9LgPfiqevSie
+        /bfwrDygIDxlRwIg0Yr+/Rx/r4tC77HZ4miZPoqylC8cSS2gz1WaogUqRbECRXeUymDZCX2j1lvN
+        JuzmChxc8VgUvnTjEYOOuW0LpgEd4mgd3SKko/VsPQ/DxLQ1w2CrwSTnmbJBOIeEggEZeArIXsci
+        rtbF14TwJR2rhIR6HBES+StIi0LWpQRRuiZA2rgICyBGt4Q08fyECClIaRMyg381SEczHRsPbXZM
+        hLR1m4N0LRFyJkA6VMq+ouEmoHQ1w6K6tNxSSsvVzK4kZZ+HdCnktQLScSyA7LkuvmDiuqUuLaxA
+        grzmITsUcqjQpQOC4aUqMEx1NavrFpC2pXVNCXLIQ3YppK+C7Jl4JMU0TbzWA1fMcylBG3LDfR6y
+        R+3ym6J7ujA9pVeA2Ahp2HzDZbv8xkMaemXq/i2FNJkujU4XL0Q0oMW21rUru9Q1G3VpUUjKI5o6
+        OEJp6iKkRSFN18E9ZdvoFJCGq3UkSNHUDbMydR7ShIb3QLye3cFJes+sIB3WPTykKKVVmToPaYDd
+        mADp9nR6Phz9Moe0NbBYAVI0dVB7aeqilB3bpDZuopSOWxqR0QXHkqQUTB1qL01danhHx3iBkABl
+        O1z31BoumDp0KJq6IUPiEUYXpQRgPElsWLyUhgQ5NHjIDoU067rsdnVwG7wSiS5qmKWU4D01SJOH
+        7JZ2ie8bIqTFjKgDURGPhFNdWo7Ld08HSND2cx7JLnulXUqQFrgNWI/uIpTr9jhIxxYhRbuECFvY
+        pQTZgx6Hfkfr0emqU2XqhilBigOFUdqlAOloho1S2t0e269z+O7pipCiXZpmaZeSlC6YCrZYpyfS
+        OwbXcEuXpBTs0rSoXRp1SAP6VWdjDyD3OhwkhFAR8po3IpN6z7VZh9ShXw0YDGnY6OrlQGFYbNAV
+        IHkjAh0VRoQvviKknUPCQAHdA5krHvJzO24B2YO4xzaHSc4jjeNuaUQSpK07BAdDYAX31LtW1T1d
+        V4SUjKhTGpEACfKBlIZmYSSCv9yeW0E6pgQpStktjUiANMCesceNLpPSsbmGmxKkZES90ogkKXtg
+        kdAvODTSgGxVkB1LklIwIksvg5ukSxMagJ4O1oNxCQy/klKGFIKbZZTBTZLSBiMCWWHoZb6kV5CO
+        LkEKwc0yy+AmQII9Q9iwwW1MKmWPh+z0ZEjeLi3qPb5CShc6BHTYRbvEwdesorol97gvSEm9x1dI
+        6YCP2DRxRUj8PotKSluGFKSkY883RfegJWKyBVDtDkRds4LUZVMXsg1IwmSHdIrMrYeDTg96GgMy
+        b+oG6tJtckirU3PIHNKA4IvODR2POTF+HwbTJbiUI0JKiXW35pA5ZLfbRcguoIAR2Rjdi/Tf7EiQ
+        opS9mkM6LKrrMIKDX5rg0O08sy6k7EhSig5p6zWHdIrEuouQPQh/+FeHg3QkXYoOaRs1h3SYXVrg
+        qxg2IQqgGnSnGsdNGVJwSNusOSSF1EE8nUaPDpXStc1Klx1TghQc0rZqDulUORF0tQ7Wg4YPplFN
+        UmwZkjd12645ZC6lDkMEDudgmGhEPaOS0nUlSMEhbafmkLmUOsiFIQiSAuz/EhId0pAhBSndmkPm
+        Urodk9lSl0Yikw9uMqTgkHandEi8KgMh3SIEW4jsQFdjJLK47nERskOviKE8okPa3dIhJcgu+AhA
+        YlIEYaNbOaTL5pAcpOiQdq90SAnS6HaYqUP7u5AbFT2Od2a4EqQ4LdVLhxQg8bCaTn+5FNK1S1MH
+        XUqQ0kzXKB1SktIF68GMGsfxLkswC0i3J0kpOCQEBZDy60qhS5t5D8weAbLr2NUc0rQlKYEfIG/w
+        loIJHgksGo4Xm/QJWiiNRD0YItDVafthvAFxmRF1wElxDqmDxSJP2fAC0lZDunTaCAbZBevBgcK0
+        q4azybOumyKk9NVExQ1mQYZnvSOtWuFRFvPrYUqCcklJWVren6Ys3W/uy8vBGkgO50nKla0zMKdl
+        oSinSags5d1OJ4i4xUAlTXF5HFtuwEUEnN6Z9BNbUtDwZjg268O5nAmJu0U/sZldWcyumbMgjbDp
+        J5azl8Xs6jkbghq7eY4FrLKYPXTAA1xVMbuiDmaw8I8aPjV+Lb+0jjeqfbJnbVTalFRaMympXOwE
+        qVBhMhLF4SyFymAUICflUJiLSg7ZWhQ0lbGgm6PrGiwwlNGBubNWEZjMzUtfLwnKuwTLvc4s2t1v
+        X7TGKxmU1MoXbtg1xQG2J0sejj/CFPee2SHlgrMJMH9DRsSdj+hN2UqGZBs/4kWV8Zpjyi+vpN8y
+        d46L3lLN38SiYsAjs1r5R6kj4xR5cohSvD4nLa86M06jU1fgbnLwPvbrElFUpHldT1XkysswWuxi
+        zOMLQUL64mGrEUF5AaEROI7TyFKeQyzh8Z6Sjy8f/7uRRdp2FPdb8+2oc5zcK4L62zitN3JKW2xv
+        r9MU2vlGTvN9GjLf3U7z3e203t1O6939Kb5karyhndaJdpYeyb7pII2+xxm7YiQD1hdNdYeKcYaH
+        vYvPf3kjXgtUHlyi22StMxi78L/oAXj2+HX17uJ9jUc/w1M+2FQ3heDXBEDi2jbdZv3k4flN+il4
+        ygcc8zmeP6PTAuOQJt8hRAqn7lL2zSFJ+nKGWRVxWyP2/SOAso3CLDongOoqOuHm4mKELW5vLP9e
+        b2F4wbtxi5vDy5LiS1Z5YuF7CMrH4td3LPyriTcg7EjfrnotzdFccBC6pwB98nW4pA1F9RO8qWTN
+        RhWtEt8EquXAG/s5VbYOt/QaQ8JTWXhlorf0FwRfqhRufeeobPFeZBhqCtUpj77w32gjkuPONqQC
+        Yu5xqabNr0IWs5QG2jyR20WpdC2cCjf693O0l5Av/jGaks+jzzOi/jZRr/8Bv1jQY2cJZ+zLn+Dz
+        8HaAX7R3cfLLioB9Pv8AU9x+eSWf4bbZ6ci2aVwMZouFv5zPptCrq1ntPnj6TUvzOf/1RMXt7KzZ
+        wt3CZgMNn1iw6+TVdMXhA/zBTBYr/T8gA6Lsl3gAAA==
+    headers:
+      Accept-Ranges:
+      - bytes
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Headers:
+      - DNT,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Range,Authorization
+      Access-Control-Allow-Methods:
+      - GET, PUT, POST, DELETE, PATCH, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Max-Age:
+      - '1728000'
+      Cache-Control:
+      - max-age=60, private
+      Connection:
+      - keep-alive
+      Content-Disposition:
+      - attachment
+      Content-Length:
+      - '7897'
+      Content-Type:
+      - application/octet-stream
+      Date:
+      - Tue, 23 Jun 2026 10:41:37 GMT
+      Etag:
+      - '"58fad1d9-1ed9"'
+      Last-Modified:
+      - Sat, 22 Apr 2017 03:45:29 GMT
+      Strict-Transport-Security:
+      - max-age=0
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/pdbe/test_fetch.py
+++ b/tests/pdbe/test_fetch.py
@@ -13,6 +13,18 @@ async def test_fetch(tmp_path: Path):
 
     results = await fetch(ids, tmp_path)
 
+    expected = {theid: tmp_path / f"{theid.lower()}_updated.cif.gz"}
+    assert results == expected
+
+
+@pytest.mark.asyncio
+@pytest.mark.vcr
+async def test_fetch_archived(tmp_path: Path):
+    theid = "2Y29"
+    ids = [theid]
+
+    results = await fetch(ids, tmp_path, archived=True)
+
     expected = {theid: tmp_path / f"{theid.lower()}.cif.gz"}
     assert results == expected
 
@@ -24,6 +36,18 @@ def test_sync_fetch(tmp_path: Path):
     ids = [theid]
 
     results = sync_fetch(ids, tmp_path)
+
+    expected = {theid: tmp_path / f"{theid.lower()}_updated.cif.gz"}
+    assert results == expected
+
+
+@pytest.mark.default_cassette("test_fetch_archived.yaml")
+@pytest.mark.vcr
+def test_sync_fetch_archived(tmp_path: Path):
+    theid = "2Y29"
+    ids = [theid]
+
+    results = sync_fetch(ids, tmp_path, archived=True)
 
     expected = {theid: tmp_path / f"{theid.lower()}.cif.gz"}
     assert results == expected

--- a/tests/structure/test_files.py
+++ b/tests/structure/test_files.py
@@ -24,6 +24,9 @@ from protein_quest.structure.types import valid_structure_file_extensions
         ("2y29", "pdb2y29.ent.gz"),
         ("2y29", "2y29.bcif"),
         ("2y29", "2y29.bcif.gz"),
+        # updated postfix
+        ("1amb", "1amb_updated.cif"),
+        ("1amb", "1amb_updated.cif.gz"),
         # cases
         ("1KVm", "1KVm.cif"),
         ("1KVm", "1kvm.cif"),
@@ -43,14 +46,24 @@ def test_locate_structure_file_notfound(tmp_path: Path):
         locate_structure_file(tmp_path, "nonexistent_id")
 
 
-def test_split_name_and_extension_without_extension(tmp_path: Path):
-    file = tmp_path / "filename"
-    file.write_text("some text")
+@pytest.mark.parametrize(
+    "file_name, expected_filename, expected_extension",
+    [
+        ("filename.txt", "filename", ".txt"),
+        ("filename.txt.gz", "filename", ".txt.gz"),
+        ("filename", "filename", ""),
+        ("1amb_updated.cif.gz", "1amb_updated", ".cif.gz"),
+    ],
+)
+def test_split_name_and_extension(
+    file_name: str,
+    expected_filename: str,
+    expected_extension: str,
+):
+    filename, extension = split_name_and_extension(file_name)
 
-    filename, extension = split_name_and_extension(file.name)
-
-    assert filename == "filename"
-    assert extension == ""
+    assert filename == expected_filename
+    assert extension == expected_extension
 
 
 def test_glob_structure_files(tmp_path: Path):


### PR DESCRIPTION
On `protein-quest retreive pdbe` command make updated version the default download and add `--archived` to download archived version

Fixes #108 