### PR TITLE
Uniprot injection on updated version cif files + Download fixtures instead of adding to repo

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Install pocl
         run: uv pip install pocl-binary-distribution==3.0
       - name: Cache downloaded test data
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: ~/.cache/protein-quest-tests
           key: cached-protein-quest-tests

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -143,6 +143,12 @@ The files downloaded for tests are cached in `~/.cache/protein-quest-tests`.
 
 Sometimes tests fail during recording, but are OK when tested again.
 
+Testing functions that use local structure files as input fixtures should not be
+added to `tests/fixtures/` directory anymore, instead use
+[pooch](https://www.fatiando.org/pooch/latest/) based
+`tests/conftest.py::fetch_cif(filename, sha256)` helper function to retrieve and
+cache files.
+
 ## Automated code quality checks on git commit
 
 This step is **optional** but recommended for developers who want to

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,6 +73,7 @@ type = [
 ]
 dev = [
     "aiohttp-compress>=0.2.1",
+    "pooch>=1.9.0",
     "pytest>=9.0.3",
     "pytest-aiohttp>=1.1.0",
     "pytest-asyncio>=1.1.0",

--- a/src/protein_quest/structure/uniprot.py
+++ b/src/protein_quest/structure/uniprot.py
@@ -164,7 +164,7 @@ def _append_uniprot_to_structure(
 
         new_seq_id = len(struct_ref_seq["align_id"]) + 1
         struct_ref_seq["align_id"].append(new_seq_id)
-        struct_ref_seq["ref_id"].append(new_seq_id)
+        struct_ref_seq["ref_id"].append(new_id)
         struct_ref_seq["pdbx_strand_id"].append(chain)
         struct_ref_seq["pdbx_db_accession"].append(uniprot_accession)
         for col in struct_ref_seq:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,8 @@
 from pathlib import Path
 
 import gemmi
+from platformdirs import user_cache_dir
+import pooch
 import pytest
 
 from protein_quest.structure.formats import read_structure, write_structure
@@ -67,6 +69,33 @@ def no_uniprot_cif(sample2_cif: Path, tmp_path: Path) -> Path:
     structure = gemmi.make_structure_from_block(block_without_struct_ref)
     write_structure(structure, tmp_path / "no_uniprot.cif")
     return tmp_path / "no_uniprot.cif"
+
+@pytest.fixture
+def download_cache_dir() -> Path:
+    cache_dir = Path(user_cache_dir("protein-quest-tests"))
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    return cache_dir
+
+
+def fetch_cif(filename: str, sha256: str) -> Path:
+    base_url = "https://www.ebi.ac.uk/pdbe/entry-files/download/"
+    path = pooch.retrieve(
+        url=f"{base_url}/{filename}",
+        known_hash=f"sha256:{sha256}",
+        fname=filename,
+        # keep path same as download_cache_dir fixture, for ci caching
+        path=pooch.os_cache("protein-quest-tests"),
+    )
+    return Path(path)
+
+
+@pytest.fixture
+def multi_entity_cif() -> Path:
+    """1f66 structure with multiple entities."""
+    return fetch_cif(
+        "1f66_updated.cif.gz",
+        "208386eac478c4deb9767f66f6ade97dc869a8d5395cdadfb385c9597442a56e",
+    )
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,9 +1,9 @@
 from pathlib import Path
 
 import gemmi
-from platformdirs import user_cache_dir
 import pooch
 import pytest
+from platformdirs import user_cache_dir
 
 from protein_quest.structure.formats import read_structure, write_structure
 
@@ -69,6 +69,7 @@ def no_uniprot_cif(sample2_cif: Path, tmp_path: Path) -> Path:
     structure = gemmi.make_structure_from_block(block_without_struct_ref)
     write_structure(structure, tmp_path / "no_uniprot.cif")
     return tmp_path / "no_uniprot.cif"
+
 
 @pytest.fixture
 def download_cache_dir() -> Path:

--- a/tests/structure/test_chains.py
+++ b/tests/structure/test_chains.py
@@ -5,7 +5,6 @@ import gemmi
 import pytest
 from cattrs import ClassValidationError
 from orjson import JSONDecodeError
-from platformdirs import user_cache_dir
 
 from protein_quest.__version__ import __version__
 from protein_quest.pdbe.fetch import sync_fetch
@@ -109,13 +108,6 @@ def test_write_single_chain_structure_file_unknown_format(tmp_path: Path):
             output_dir=tmp_path,
             out_chain="Z",
         )
-
-
-@pytest.fixture
-def download_cache_dir() -> Path:
-    cache_dir = Path(user_cache_dir("protein-quest-tests"))
-    cache_dir.mkdir(parents=True, exist_ok=True)
-    return cache_dir
 
 
 def fetch_pdb_file_cached(pdb_id: str, download_cache_dir: Path) -> Path:

--- a/tests/structure/test_uniprot.py
+++ b/tests/structure/test_uniprot.py
@@ -191,7 +191,7 @@ class TestStructureToUniprot:
         assert result == expected
 
 
-class TestVerifyInjectUniprotRef:
+class TestAddUniprotAccessions2Structure:
     def test_none(self, sample2_cif: Path):
         structure = read_structure(sample2_cif)
 
@@ -254,3 +254,59 @@ class TestVerifyInjectUniprotRef:
         log = caplog.text
         assert "Structure 1A02 has provenance information indicating it was extracted from chain F to A" in log
         assert "Using this information to verify/add UniProt accessions." in log
+
+    def test_multi_entity_cif(self, multi_entity_cif: Path):
+        structure = read_structure(multi_entity_cif)
+        # From `echo P0C0S5 | protein-quest search pdbe - - |grep 1F66` gives `P0C0S5,1F66,X-Ray_Crystallography,2.6,C/G=1-128,C,128`
+        pdb2uniprot = {"1F66": {("C", "P0C0S5")}}
+
+        new_structure = add_uniprot_accessions2structure(structure, pdb2uniprot)
+
+        result = structure_to_uniprot(new_structure)
+
+        # TODO wrong expectations, result should have ("C","P0C0S5") in it
+        expected: Pdb2UniprotMapping = {
+            "1F66": {
+                (
+                    "A",
+                    "P0C0S5",
+                ),
+                (
+                    "A",
+                    "Q7ZT64",
+                ),
+                (
+                    "B",
+                    "P62806",
+                ),
+                (
+                    "C",
+                    "P17317",
+                ),
+                (
+                    "D",
+                    "P02281",
+                ),
+                (
+                    "E",
+                    "P0C0S5",
+                ),
+                (
+                    "E",
+                    "Q7ZT64",
+                ),
+                (
+                    "F",
+                    "P62806",
+                ),
+                (
+                    "G",
+                    "P17317",
+                ),
+                (
+                    "H",
+                    "P02281",
+                ),
+            },
+        }
+        assert result == expected

--- a/uv.lock
+++ b/uv.lock
@@ -2109,6 +2109,20 @@ wheels = [
 ]
 
 [[package]]
+name = "pooch"
+version = "1.9.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "packaging" },
+    { name = "platformdirs" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/83/43/85ef45e8b36c6a48546af7b266592dc32d7f67837a6514d111bced6d7d75/pooch-1.9.0.tar.gz", hash = "sha256:de46729579b9857ffd3e741987a2f6d5e0e03219892c167c6578c0091fb511ed", size = 61788, upload-time = "2026-01-30T19:15:09.649Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/2d/d4bf65e47cea8ff2c794a600c4fd1273a7902f268757c531e0ee9f18aa58/pooch-1.9.0-py3-none-any.whl", hash = "sha256:f265597baa9f760d25ceb29d0beb8186c243d6607b0f60b83ecf14078dbc703b", size = 67175, upload-time = "2026-01-30T19:15:08.36Z" },
+]
+
+[[package]]
 name = "prompt-toolkit"
 version = "3.0.52"
 source = { registry = "https://pypi.org/simple" }
@@ -2222,6 +2236,7 @@ mcp = [
 [package.dev-dependencies]
 dev = [
     { name = "aiohttp-compress" },
+    { name = "pooch" },
     { name = "pyrefly" },
     { name = "pytest" },
     { name = "pytest-aiohttp" },
@@ -2277,6 +2292,7 @@ provides-extras = ["mcp"]
 [package.metadata.requires-dev]
 dev = [
     { name = "aiohttp-compress", specifier = ">=0.2.1" },
+    { name = "pooch", specifier = ">=1.9.0" },
     { name = "pyrefly", specifier = ">=1.1.1" },
     { name = "pytest", specifier = ">=9.0.3" },
     { name = "pytest-aiohttp", specifier = ">=1.1.0" },


### PR DESCRIPTION
Fixes #117 , this pr fixes runtime error only, for chain ambiguity see #119, which will be another PR.
Fixes #113