### PR TITLE
Case insensitive exp method matching

### DIFF
--- a/src/protein_quest/structure/chains.py
+++ b/src/protein_quest/structure/chains.py
@@ -29,7 +29,8 @@ ChainIdSystem = Literal["auth", "label"]
 If they differ, chain ids are shown as
 ``label_asym_id [auth auth_asym_id]`` on [https://www.rcsb.org/](https://www.rcsb.org/).
 
-For more information see [rcsb help](https://www.rcsb.org/docs/general-help/identifiers-in-pdb#macromolecular-instance-id).
+For more information see [rcsb help](https://www.rcsb.org/docs/general-help/identifiers-in-pdb#macromolecular-instance-id)
+and [gemmi documentation](https://gemmi.readthedocs.io/en/latest/cif.html#auth-vs-label)
 """
 
 

--- a/src/protein_quest/structure/formats.py
+++ b/src/protein_quest/structure/formats.py
@@ -21,6 +21,15 @@ from protein_quest.utils import user_cache_root_dir
 logger = logging.getLogger(__name__)
 
 
+def _is_em_method(structure: gemmi.Structure) -> bool:
+    # Not reusing ./metadata.py::_structure_method to preven circular import
+    try:
+        experimental_method = structure.info["_exptl.method"].lower()
+    except KeyError:
+        experimental_method = ""
+    return "electron microscopy" in experimental_method
+
+
 def _make_mmcif_document(structure: gemmi.Structure) -> gemmi.cif.Document:
     """Create an mmCIF document and preserve EM resolution metadata when needed."""
     # do not write chem_comp so it is viewable by molstar
@@ -28,11 +37,7 @@ def _make_mmcif_document(structure: gemmi.Structure) -> gemmi.cif.Document:
     doc = structure.make_mmcif_document(gemmi.MmcifOutputGroups(True, chem_comp=False))
     # Gemmi reads EM resolution into Structure.resolution from
     # _em_3d_reconstruction.resolution, but does not emit that category again.
-    try:
-        experimental_method = structure.info["_exptl.method"]
-    except KeyError:
-        experimental_method = None
-    if structure.resolution > 0 and experimental_method == "Electron Microscopy":
+    if structure.resolution > 0 and _is_em_method(structure):
         block = doc.sole_block()
         if not block.find_value("_em_3d_reconstruction.resolution"):
             block.set_pair("_em_3d_reconstruction.entry_id", structure.name)

--- a/src/protein_quest/structure/formats.py
+++ b/src/protein_quest/structure/formats.py
@@ -22,7 +22,7 @@ logger = logging.getLogger(__name__)
 
 
 def _is_em_method(structure: gemmi.Structure) -> bool:
-    # Not reusing ./metadata.py::_structure_method to preven circular import
+    # Could have used ./metadata.py::_structure_method, but do not to prevent circular import
     try:
         experimental_method = structure.info["_exptl.method"].lower()
     except KeyError:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -118,6 +118,30 @@ def cif_3jrs() -> Path:
 
 
 @pytest.fixture
+def fake_archive_em_structure() -> gemmi.Structure:
+    structure = gemmi.Structure()
+    structure.name = "1ABC"
+    # Archived structures use UPPERCASE as exp method value
+    structure.info["_exptl.method"] = "ELECTRON MICROSCOPY"
+    structure.resolution = 4.2
+    atom = gemmi.Atom()
+    atom.name = "CA"
+    atom.element = gemmi.Element("C")
+    residue = gemmi.Residue()
+    residue.name = "ALA"
+    residue.add_atom(atom)
+    residue.entity_type = gemmi.EntityType.Polymer
+    chain = gemmi.Chain("A")
+    chain.add_residue(residue)
+    model = gemmi.Model(1)
+    model.add_chain(chain)
+    structure.add_model(model)
+    structure.setup_entities()
+    structure.assign_subchains()
+    return structure
+
+
+@pytest.fixture
 def all_cifs(
     sample_cif: Path,
     sample2_cif: Path,

--- a/tests/structure/test_formats.py
+++ b/tests/structure/test_formats.py
@@ -1,6 +1,7 @@
 import gzip
 from pathlib import Path
 
+import gemmi
 import pytest
 
 from protein_quest.structure.formats import (
@@ -79,3 +80,15 @@ def test_em_structure_retains_resolution(em_cif: Path, tmp_path: Path, output_fn
     written_structure = read_structure(output_file)
 
     assert written_structure.resolution == 3.61
+
+
+def test_em_archived_structure_retains_resolution(fake_archive_em_structure: gemmi.Structure, tmp_path: Path):
+    structure = fake_archive_em_structure
+    assert structure.resolution == 4.2
+    output_file = tmp_path / "em_structure.cif"
+
+    write_structure(structure, output_file)
+
+    written_structure = read_structure(output_file)
+
+    assert written_structure.resolution == 4.2

--- a/tests/structure/test_metadata.py
+++ b/tests/structure/test_metadata.py
@@ -215,3 +215,22 @@ class TestStructureMetadata:
 
         with pytest.raises(ValueError, match="No chains found in structure EMPTY"):
             structure_metadata(structure)
+
+    def test_archived_em_structure(self, fake_archive_em_structure: gemmi.Structure):
+        result = structure_metadata(fake_archive_em_structure)
+
+        expected = StructureMetadata(
+            id="1ABC",
+            uniprot_accession=None,
+            resolution=4.2,
+            total_residue_count=1,
+            is_alphafold=False,
+            uniprot_start=0,
+            uniprot_end=0,
+            sequence_identity=0.0,
+            chain_length=1,
+            auth_chain="A",
+            label_chain="Axp",
+            method="EM",
+        )
+        assert result == expected


### PR DESCRIPTION
Reading exp method for structure metadata was already case-insensitive, added test for good measure.
 
For injecting EM resolution made it case-insensitive.

Fixes #116