### PR TITLE
Make sparql query deterministic by sorting uniprot accessions

### DIFF
--- a/src/protein_quest/__version__.py
+++ b/src/protein_quest/__version__.py
@@ -1,2 +1,2 @@
-__version__ = "1.5.1"
+__version__ = "1.5.2"
 """The version of the package."""

--- a/src/protein_quest/sparql.py
+++ b/src/protein_quest/sparql.py
@@ -50,6 +50,7 @@ def build_sparql_generic_by_uniprot_accessions_query(
 
     Args:
         uniprot_accs: An iterable of UniProt accessions to filter by.
+            Sorted and unique accessions will be used in the query.
         select_clause: The SELECT clause of the SPARQL query, without the "SELECT" keyword.
         where_clause: The WHERE clause of the SPARQL query, without the "WHERE" keyword.
         limit: The maximum number of results to return. Default is 10,000.
@@ -58,7 +59,8 @@ def build_sparql_generic_by_uniprot_accessions_query(
     Returns:
         A string containing the complete SPARQL query.
     """
-    values = " ".join(f'("{ac}")' for ac in uniprot_accs)
+    sorted_auniprot_accs = sorted(set(uniprot_accs))
+    values = " ".join(f'("{ac}")' for ac in sorted_auniprot_accs)
     where_clause2 = dedent(f"""
         # --- Protein Selection ---
         VALUES (?ac) {{ {values}}}

--- a/tests/cassettes/test_uniprot/test_map_uniprot_accessions2uniprot_details.yaml
+++ b/tests/cassettes/test_uniprot/test_map_uniprot_accessions2uniprot_details.yaml
@@ -11,7 +11,7 @@ interactions:
       User-Agent:
       - sparqlwrapper 2.0.0 (rdflib.github.io/sparqlwrapper)
     method: GET
-    uri: https://sparql.uniprot.org/sparql?query=%0A++++++++PREFIX+up%3A+%3Chttp%3A//purl.uniprot.org/core/%3E%0A++++++++PREFIX+taxon%3A+%3Chttp%3A//purl.uniprot.org/taxonomy/%3E%0A++++++++PREFIX+rdf%3A+%3Chttp%3A//www.w3.org/1999/02/22-rdf-syntax-ns%23%3E%0A++++++++PREFIX+rdfs%3A+%3Chttp%3A//www.w3.org/2000/01/rdf-schema%23%3E%0A++++++++PREFIX+skos%3A+%3Chttp%3A//www.w3.org/2004/02/skos/core%23%3E%0A++++++++PREFIX+GO%3A%3Chttp%3A//purl.obolibrary.org/obo/GO_%3E%0A%0A++++++++SELECT+%28%3Fac+AS+%3Funiprot_accession%29%0A%3Funiprot_id%0A%28STRAFTER%28STR%28%3Forganism%29%2C+%22taxonomy/%22%29+AS+%3Ftaxon_id%29%0A%3Ftaxon_name%0A%3Freviewed%0A%3Fprotein_name%0A%28STRLEN%28%3Fsequence%29+AS+%3Fseq_length%29%0A%0A++++++++WHERE+%7B%0A%0A++++++++%23+---+Protein+Selection+---%0A++++++++VALUES+%28%3Fac%29+%7B+%28%22P05067%22%29+%28%22A6NGD5%22%29+%28%22O14627%22%29+%28%22P00697%22%29+%28%22P42284%22%29+%28%22A0A0B5AC95%22%29+%28%22A0A0S2Z4R0%22%29%7D%0A++++++++BIND+%28IRI%28CONCAT%28%22http%3A//purl.uniprot.org/uniprot/%22%2C%3Fac%29%29+AS+%3Fprotein%29%0A++++++++%3Fprotein+a+up%3AProtein+.%0A%0A%0A%3Fprotein+up%3Amnemonic+%3Funiprot_id+.%0A%3Fprotein+up%3Aorganism+%3Forganism+.%0A%3Forganism+up%3AscientificName+%3Ftaxon_name+.%0A%3Fprotein+up%3Areviewed+%3Freviewed+.%0AOPTIONAL+%7B%0A%3Fprotein+up%3ArecommendedName/up%3AfullName+%3Fprotein_name+.%0A%7D%0A%3Fprotein+up%3Asequence+%3Fisoform+.%0A%3Fisoform+a+up%3ASimple_Sequence+.%0A%3Fisoform+rdf%3Avalue+%3Fsequence+.%0ABIND+%28IRI%28STRBEFORE%28REPLACE%28%0A++++STR%28%3Fisoform%29%2C+%22http%3A//purl.uniprot.org/isoforms/%22%2C+%22http%3A//purl.uniprot.org/uniprot/%22%0A%29%2C+%22-%22%29%29+AS+%3Fac_of_isoform%29%0AFILTER%28%3Fac_of_isoform+%3D+%3Fprotein%29%0A%0A%0A++++++++%7D%0A%0A++++++++LIMIT+1000%0A&format=json&output=json&results=json
+    uri: https://sparql.uniprot.org/sparql?query=%0A++++++++PREFIX+up%3A+%3Chttp%3A//purl.uniprot.org/core/%3E%0A++++++++PREFIX+taxon%3A+%3Chttp%3A//purl.uniprot.org/taxonomy/%3E%0A++++++++PREFIX+rdf%3A+%3Chttp%3A//www.w3.org/1999/02/22-rdf-syntax-ns%23%3E%0A++++++++PREFIX+rdfs%3A+%3Chttp%3A//www.w3.org/2000/01/rdf-schema%23%3E%0A++++++++PREFIX+skos%3A+%3Chttp%3A//www.w3.org/2004/02/skos/core%23%3E%0A++++++++PREFIX+GO%3A%3Chttp%3A//purl.obolibrary.org/obo/GO_%3E%0A%0A++++++++SELECT+%28%3Fac+AS+%3Funiprot_accession%29%0A%3Funiprot_id%0A%28STRAFTER%28STR%28%3Forganism%29%2C+%22taxonomy/%22%29+AS+%3Ftaxon_id%29%0A%3Ftaxon_name%0A%3Freviewed%0A%3Fprotein_name%0A%28STRLEN%28%3Fsequence%29+AS+%3Fseq_length%29%0A%0A++++++++WHERE+%7B%0A%0A++++++++%23+---+Protein+Selection+---%0A++++++++VALUES+%28%3Fac%29+%7B+%28%22A0A0B5AC95%22%29+%28%22A0A0S2Z4R0%22%29+%28%22A6NGD5%22%29+%28%22O14627%22%29+%28%22P00697%22%29+%28%22P05067%22%29+%28%22P42284%22%29%7D%0A++++++++BIND+%28IRI%28CONCAT%28%22http%3A//purl.uniprot.org/uniprot/%22%2C%3Fac%29%29+AS+%3Fprotein%29%0A++++++++%3Fprotein+a+up%3AProtein+.%0A%0A%0A%3Fprotein+up%3Amnemonic+%3Funiprot_id+.%0A%3Fprotein+up%3Aorganism+%3Forganism+.%0A%3Forganism+up%3AscientificName+%3Ftaxon_name+.%0A%3Fprotein+up%3Areviewed+%3Freviewed+.%0AOPTIONAL+%7B%0A%3Fprotein+up%3ArecommendedName/up%3AfullName+%3Fprotein_name+.%0A%7D%0A%3Fprotein+up%3Asequence+%3Fisoform+.%0A%3Fisoform+a+up%3ASimple_Sequence+.%0A%3Fisoform+rdf%3Avalue+%3Fsequence+.%0ABIND+%28IRI%28STRBEFORE%28REPLACE%28%0A++++STR%28%3Fisoform%29%2C+%22http%3A//purl.uniprot.org/isoforms/%22%2C+%22http%3A//purl.uniprot.org/uniprot/%22%0A%29%2C+%22-%22%29%29+AS+%3Fac_of_isoform%29%0AFILTER%28%3Fac_of_isoform+%3D+%3Fprotein%29%0A%0A%0A++++++++%7D%0A%0A++++++++LIMIT+1000%0A&format=json&output=json&results=json
   response:
     body:
       string: "{\n  \"head\" : {\n    \"vars\" : [\n      \"uniprot_accession\",\n
@@ -112,17 +112,17 @@ interactions:
       Connection:
       - close
       Content-Disposition:
-      - attachment; filename="sparql-8E0F2D964C49FC567BFD68E12DD773F9.srj"
+      - attachment; filename="sparql-0A8054F546D892423DA8C83C6AD66FFF.srj"
       Content-Length:
       - '6132'
       Content-Type:
       - application/sparql-results+json
       Date:
-      - Wed, 29 Oct 2025 13:02:57 GMT
+      - Tue, 21 Jul 2026 06:55:47 GMT
       ETag:
-      - W/"2025_04"
+      - W/"2026_02"
       Expires:
-      - Thu, 30 Oct 2025 13:02:51 GMT
+      - Wed, 22 Jul 2026 06:55:44 GMT
       Server:
       - Apache
       Strict-Transport-Security:
@@ -136,9 +136,9 @@ interactions:
       X-Powered-By:
       - sib.swiss
       X-Release:
-      - '2025_04'
+      - '2026_02'
       queryid:
-      - '570183220'
+      - '-404'
     status:
       code: 200
       message: ''

--- a/tests/cli/cassettes/test_search/test_search_uniprot_details.yaml
+++ b/tests/cli/cassettes/test_search/test_search_uniprot_details.yaml
@@ -11,7 +11,7 @@ interactions:
       User-Agent:
       - sparqlwrapper 2.0.0 (rdflib.github.io/sparqlwrapper)
     method: GET
-    uri: https://sparql.uniprot.org/sparql?query=%0A++++++++PREFIX+up%3A+%3Chttp%3A//purl.uniprot.org/core/%3E%0A++++++++PREFIX+taxon%3A+%3Chttp%3A//purl.uniprot.org/taxonomy/%3E%0A++++++++PREFIX+rdf%3A+%3Chttp%3A//www.w3.org/1999/02/22-rdf-syntax-ns%23%3E%0A++++++++PREFIX+rdfs%3A+%3Chttp%3A//www.w3.org/2000/01/rdf-schema%23%3E%0A++++++++PREFIX+skos%3A+%3Chttp%3A//www.w3.org/2004/02/skos/core%23%3E%0A++++++++PREFIX+GO%3A%3Chttp%3A//purl.obolibrary.org/obo/GO_%3E%0A%0A++++++++SELECT+%28%3Fac+AS+%3Funiprot_accession%29%0A%3Funiprot_id%0A%28STRAFTER%28STR%28%3Forganism%29%2C+%22taxonomy/%22%29+AS+%3Ftaxon_id%29%0A%3Ftaxon_name%0A%3Freviewed%0A%3Fprotein_name%0A%28STRLEN%28%3Fsequence%29+AS+%3Fseq_length%29%0A%0A++++++++WHERE+%7B%0A%0A++++++++%23+---+Protein+Selection+---%0A++++++++VALUES+%28%3Fac%29+%7B+%28%22P05067%22%29+%28%22A0A0B5AC95%22%29%7D%0A++++++++BIND+%28IRI%28CONCAT%28%22http%3A//purl.uniprot.org/uniprot/%22%2C%3Fac%29%29+AS+%3Fprotein%29%0A++++++++%3Fprotein+a+up%3AProtein+.%0A%0A%0A%3Fprotein+up%3Amnemonic+%3Funiprot_id+.%0A%3Fprotein+up%3Aorganism+%3Forganism+.%0A%3Forganism+up%3AscientificName+%3Ftaxon_name+.%0A%3Fprotein+up%3Areviewed+%3Freviewed+.%0AOPTIONAL+%7B%0A%3Fprotein+up%3ArecommendedName/up%3AfullName+%3Fprotein_name+.%0A%7D%0A%3Fprotein+up%3Asequence+%3Fisoform+.%0A%3Fisoform+a+up%3ASimple_Sequence+.%0A%3Fisoform+rdf%3Avalue+%3Fsequence+.%0ABIND+%28IRI%28STRBEFORE%28REPLACE%28%0A++++STR%28%3Fisoform%29%2C+%22http%3A//purl.uniprot.org/isoforms/%22%2C+%22http%3A//purl.uniprot.org/uniprot/%22%0A%29%2C+%22-%22%29%29+AS+%3Fac_of_isoform%29%0AFILTER%28%3Fac_of_isoform+%3D+%3Fprotein%29%0A%0A%0A++++++++%7D%0A%0A++++++++LIMIT+1000%0A&format=json&output=json&results=json
+    uri: https://sparql.uniprot.org/sparql?query=%0A++++++++PREFIX+up%3A+%3Chttp%3A//purl.uniprot.org/core/%3E%0A++++++++PREFIX+taxon%3A+%3Chttp%3A//purl.uniprot.org/taxonomy/%3E%0A++++++++PREFIX+rdf%3A+%3Chttp%3A//www.w3.org/1999/02/22-rdf-syntax-ns%23%3E%0A++++++++PREFIX+rdfs%3A+%3Chttp%3A//www.w3.org/2000/01/rdf-schema%23%3E%0A++++++++PREFIX+skos%3A+%3Chttp%3A//www.w3.org/2004/02/skos/core%23%3E%0A++++++++PREFIX+GO%3A%3Chttp%3A//purl.obolibrary.org/obo/GO_%3E%0A%0A++++++++SELECT+%28%3Fac+AS+%3Funiprot_accession%29%0A%3Funiprot_id%0A%28STRAFTER%28STR%28%3Forganism%29%2C+%22taxonomy/%22%29+AS+%3Ftaxon_id%29%0A%3Ftaxon_name%0A%3Freviewed%0A%3Fprotein_name%0A%28STRLEN%28%3Fsequence%29+AS+%3Fseq_length%29%0A%0A++++++++WHERE+%7B%0A%0A++++++++%23+---+Protein+Selection+---%0A++++++++VALUES+%28%3Fac%29+%7B+%28%22A0A0B5AC95%22%29+%28%22P05067%22%29%7D%0A++++++++BIND+%28IRI%28CONCAT%28%22http%3A//purl.uniprot.org/uniprot/%22%2C%3Fac%29%29+AS+%3Fprotein%29%0A++++++++%3Fprotein+a+up%3AProtein+.%0A%0A%0A%3Fprotein+up%3Amnemonic+%3Funiprot_id+.%0A%3Fprotein+up%3Aorganism+%3Forganism+.%0A%3Forganism+up%3AscientificName+%3Ftaxon_name+.%0A%3Fprotein+up%3Areviewed+%3Freviewed+.%0AOPTIONAL+%7B%0A%3Fprotein+up%3ArecommendedName/up%3AfullName+%3Fprotein_name+.%0A%7D%0A%3Fprotein+up%3Asequence+%3Fisoform+.%0A%3Fisoform+a+up%3ASimple_Sequence+.%0A%3Fisoform+rdf%3Avalue+%3Fsequence+.%0ABIND+%28IRI%28STRBEFORE%28REPLACE%28%0A++++STR%28%3Fisoform%29%2C+%22http%3A//purl.uniprot.org/isoforms/%22%2C+%22http%3A//purl.uniprot.org/uniprot/%22%0A%29%2C+%22-%22%29%29+AS+%3Fac_of_isoform%29%0AFILTER%28%3Fac_of_isoform+%3D+%3Fprotein%29%0A%0A%0A++++++++%7D%0A%0A++++++++LIMIT+1000%0A&format=json&output=json&results=json
   response:
     body:
       string: "{\n  \"head\" : {\n    \"vars\" : [\n      \"uniprot_accession\",\n
@@ -54,17 +54,17 @@ interactions:
       Connection:
       - close
       Content-Disposition:
-      - attachment; filename="sparql-8C554C701C4231F3E0F6C98B62AFB49F.srj"
+      - attachment; filename="sparql-3A59C61B8A8959E8F3E21EC0896067B8.srj"
       Content-Length:
       - '1904'
       Content-Type:
       - application/sparql-results+json
       Date:
-      - Fri, 03 Apr 2026 17:59:03 GMT
+      - Tue, 21 Jul 2026 06:55:44 GMT
       ETag:
-      - W/"2026_01"
+      - W/"2026_02"
       Expires:
-      - Sat, 04 Apr 2026 17:58:58 GMT
+      - Wed, 22 Jul 2026 06:55:40 GMT
       Server:
       - Apache
       Strict-Transport-Security:
@@ -78,9 +78,9 @@ interactions:
       X-Powered-By:
       - sib.swiss
       X-Release:
-      - '2026_01'
+      - '2026_02'
       queryid:
-      - '2270056087'
+      - '-404'
     status:
       code: 200
       message: ''


### PR DESCRIPTION
When using set of uniprot accessions they can stringified in undeterministic order. This causes vcr recordings not matching.