### PR TITLE
Nicer console messages + more portable tests

### DIFF
--- a/src/protein_quest/__version__.py
+++ b/src/protein_quest/__version__.py
@@ -1,2 +1,2 @@
-__version__ = "1.5.3"
+__version__ = "1.5.4"
 """The version of the package."""

--- a/src/protein_quest/cli/retrieve.py
+++ b/src/protein_quest/cli/retrieve.py
@@ -76,7 +76,7 @@ def pdbe(
             pdb_ids, output_dir, archived=archived, max_parallel_downloads=max_parallel_downloads, cacher=cacher
         )
     )
-    rprint(f"Retrieved {len(result)} PDBe entries")
+    rprint(f"Retrieved {len(result)} PDBe entries, written to {output_dir}")
 
 
 @retrieve_app.command
@@ -140,7 +140,8 @@ def alphafold(
         all_isoforms=all_isoforms,
     )
     total_nr_files = sum(af.nr_of_files() for af in afs)
-    rprint(f"Retrieved {total_nr_files} AlphaFold files and {len(afs)} summaries, written to {output_dir}")
+    total_nr_summaries = sum(1 for af in afs if af.summary is not None)
+    rprint(f"Retrieved {total_nr_files} AlphaFold files and {total_nr_summaries} summaries, written to {output_dir}")
 
 
 @retrieve_app.command

--- a/tests/filters/test_combined.py
+++ b/tests/filters/test_combined.py
@@ -55,7 +55,7 @@ class TestCombinedFilter:
         input_files = []
         for cif in all_cifs:
             input_file = input_dir / cif.name
-            input_file.hardlink_to(cif)
+            input_file.symlink_to(cif)
             input_files.append(input_file)
         scores: dict[str, Scores] = {}
         query = CombinedFilterQuery(min_sequence_identity=0.8)
@@ -235,7 +235,7 @@ class TestCombinedFilter:
         input_files = []
         for cif in bad_cifs:
             input_file = input_dir / cif.name
-            input_file.hardlink_to(cif)
+            input_file.symlink_to(cif)
             input_files.append(input_file)
         scores: dict[str, Scores] = {}
         query = CombinedFilterQuery()
@@ -295,7 +295,7 @@ class TestCombinedFilter:
         input_dir = tmp_path / "input"
         input_dir.mkdir()
         input_file = input_dir / nmr_cif.name
-        input_file.hardlink_to(nmr_cif)
+        input_file.symlink_to(nmr_cif)
         scores: dict[str, Scores] = {
             "1amb": Scores(
                 geometry_quality=70.3,
@@ -341,7 +341,7 @@ class TestCombinedFilter:
         input_dir = tmp_path / "input"
         input_dir.mkdir()
         input_file = input_dir / af_cif.name
-        input_file.hardlink_to(af_cif)
+        input_file.symlink_to(af_cif)
         scores: dict[str, Scores] = {}
         query = CombinedFilterQuery(
             min_residues=20,
@@ -382,7 +382,7 @@ class TestCombinedFilter:
         input_dir = tmp_path / "input"
         input_dir.mkdir()
         input_file = input_dir / sample2_cif.name
-        input_file.hardlink_to(sample2_cif)
+        input_file.symlink_to(sample2_cif)
         scores: dict[str, Scores] = {}
         query = CombinedFilterQuery(
             min_residues=20,
@@ -425,7 +425,7 @@ class TestCombinedFilter:
         input_files = []
         for cif in xray_p05067_cifs:
             input_file = input_dir / cif.name
-            input_file.hardlink_to(cif)
+            input_file.symlink_to(cif)
             input_files.append(input_file)
         scores: dict[str, Scores] = {}
         query = CombinedFilterQuery(
@@ -730,7 +730,7 @@ class TestCombinedFilter:
         input_files = []
         for cif in [sample_multispan_cif, multi_accession_chain_cif]:
             input_file = input_dir / cif.name
-            input_file.hardlink_to(cif)
+            input_file.symlink_to(cif)
             input_files.append(input_file)
         scores: dict[str, Scores] = {}
         query = CombinedFilterQuery(min_sequence_identity=0.9)

--- a/tests/filters/test_resolution.py
+++ b/tests/filters/test_resolution.py
@@ -384,7 +384,11 @@ class TestFilterFilesOnResolution:
 
     def test_lax_mode_passes_structure_without_resolution(self, af_cif: Path, tmp_path: Path):
         output_dir = tmp_path / "output"
-        results = list(filter_files_on_resolution(input_files=[af_cif], output_dir=output_dir, top=1, lax=True))
+        results = list(
+            filter_files_on_resolution(
+                input_files=[af_cif], output_dir=output_dir, top=1, lax=True, copy_method="symlink"
+            )
+        )
 
         expected = ResolutionFilterStatistics(
             id="AF-A0A0C5B5G6-F1",


### PR DESCRIPTION
Use symlinks in tests instead of hardlinks.
So when /tmp and cwd are on different partitions tests still pass