### PR TITLE
Add --scheduler-address to filter `secondary-structure` and `convert structures` commands

### DIFF
--- a/src/protein_quest/__version__.py
+++ b/src/protein_quest/__version__.py
@@ -1,2 +1,2 @@
-__version__ = "1.5.4"
+__version__ = "1.5.5"
 """The version of the package."""

--- a/src/protein_quest/cli/convert.py
+++ b/src/protein_quest/cli/convert.py
@@ -26,8 +26,9 @@ from protein_quest.clustering_io import (
     write_stats_csv,
 )
 from protein_quest.filters.resolution import load_resolution_statistics
+from protein_quest.parallel import map_with_progress
 from protein_quest.structure.chains import ChainIdSystem
-from protein_quest.structure.convert import convert_to_cif_files, write_conversion_stats
+from protein_quest.structure.convert import convert_to_cif_file, write_conversion_stats
 from protein_quest.structure.files import glob_structure_files
 from protein_quest.structure.formats import read_structure
 from protein_quest.structure.types import CifOutputFormat
@@ -126,6 +127,7 @@ def structures(
     output_format: CifOutputFormat = ".cif.gz",
     uniprots: InputFile | None = None,
     chain_system: ChainIdSystem = "auth",
+    scheduler_address: str | None = None,
     cache: CacheParameter | None = None,
     write_stats: OutputFile | None = None,
     _common: Common | None = None,
@@ -149,6 +151,9 @@ def structures(
             Set to 'label' to use chain ids assigned by PDB.
             See [docs](https://www.bonvinlab.org/protein_quest/autoapi/protein_quest/structure/chains.html#protein_quest.structure.chains.ChainIdSystem)
             for more information on chain id system.
+        scheduler_address: Address of the Dask scheduler to connect to.
+            If not provided, will create a local cluster.
+            If set to `sequential` will run tasks sequentially.
         output_format: Output format for converted files. Supported values are .cif and .cif.gz.
         cache: Cache options including no_cache, cache_dir, and copy_method.
         write_stats: Optional output CSV file with per-file conversion statistics.
@@ -165,19 +170,19 @@ def structures(
 
     pdb2uniprot = _read_pdb2uniprot_csv(uniprots)
 
-    results = list(
-        tqdm(
-            convert_to_cif_files(
-                input_files,
-                output_dir,
-                copy_method=cache.copy_method,
-                output_format=output_format,
-                pdb2uniprot=pdb2uniprot,
-                chain_system=chain_system,
-            ),
-            total=len(input_files),
-            unit="file",
-        )
+    results = map_with_progress(
+        scheduler_address,
+        convert_to_cif_file,
+        input_files,
+        map_with_progress_options={
+            "tqdm_desc": "Converting structures",
+            "tqdm_unit": "file",
+        },
+        output_dir=output_dir,
+        copy_method=cache.copy_method,
+        output_format=output_format,
+        pdb2uniprot=pdb2uniprot,
+        chain_system=chain_system,
     )
 
     rprint(f"Converted {len(input_files)} files into {output_dir}.")

--- a/src/protein_quest/cli/filter.py
+++ b/src/protein_quest/cli/filter.py
@@ -39,7 +39,11 @@ from protein_quest.filters.resolution import (
     filter_files_on_resolution,
     write_resolution_stats,
 )
-from protein_quest.filters.ss import SecondaryStructureFilterQuery, filter_files_on_secondary_structure
+from protein_quest.filters.ss import (
+    SecondaryStructureFilterQuery,
+    filter_file_on_secondary_structure,
+)
+from protein_quest.parallel import map_with_progress
 from protein_quest.structure.chains import ChainIdSystem
 from protein_quest.structure.files import glob_structure_files, locate_structure_file
 from protein_quest.utils import copyfile
@@ -458,6 +462,7 @@ def secondary_structure(
     /,
     *,
     filters: SecondaryStructureFilterQuery | None = None,
+    scheduler_address: str | None = None,
     write_stats: OutputFile | None = None,
     cache: CacheParameter | None = None,
     _: Common | None = None,
@@ -470,6 +475,9 @@ def secondary_structure(
         input_dir: Directory with PDB/mmCIF files.
         output_dir: Directory to write filtered PDB/mmCIF files. Files are copied without modification.
         filters: Secondary structure filtering criteria.
+        scheduler_address: Address of the Dask scheduler to connect to.
+            If not provided, will create a local cluster.
+            If set to `sequential` will run tasks sequentially.
         write_stats: Write filter statistics to file.
             In CSV format with columns:
             `<input_file>,<nr_residues>,<nr_helix_residues>,<nr_sheet_residues>,
@@ -495,7 +503,14 @@ def secondary_structure(
 
     rprint(f"Filtering {nr_total} files in {input_dir} directory by secondary structure.")
     nr_passed = 0
-    for input_file, result in filter_files_on_secondary_structure(input_files, query=filters):
+    results = map_with_progress(
+        scheduler_address,
+        filter_file_on_secondary_structure,
+        input_files,
+        map_with_progress_options={"tqdm_desc": "Filtering on secondary structure", "tqdm_unit": "file"},
+        query=filters,
+    )
+    for input_file, result in zip(input_files, results, strict=True):
         output_file: Path | None = None
         if result.passed:
             output_file = output_dir / input_file.name

--- a/src/protein_quest/filters/ss.py
+++ b/src/protein_quest/filters/ss.py
@@ -1,7 +1,6 @@
 """Module for dealing with secondary structure."""
 
 import logging
-from collections.abc import Generator, Iterable
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
@@ -247,22 +246,3 @@ def filter_file_on_secondary_structure(
     """
     structure = read_structure(file_path)
     return filter_on_secondary_structure(structure, query)
-
-
-def filter_files_on_secondary_structure(
-    file_paths: Iterable[Path],
-    query: SecondaryStructureFilterQuery,
-) -> Generator[tuple[Path, SecondaryStructureFilterResult]]:
-    """Filter multiple structure files based on secondary structure criteria.
-
-    Args:
-        file_paths: A list of paths to the structure files to analyze.
-        query: The filtering criteria to apply.
-
-    Yields:
-        For each file returns the filtering statistics and whether structure passed.
-    """
-    # TODO check if quick enough in serial mode, if not switch to dask map
-    for file_path in file_paths:
-        result = filter_file_on_secondary_structure(file_path, query)
-        yield file_path, result

--- a/src/protein_quest/structure/convert.py
+++ b/src/protein_quest/structure/convert.py
@@ -2,7 +2,7 @@
 
 import csv
 import logging
-from collections.abc import Generator, Iterable
+from collections.abc import Iterable
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -43,39 +43,6 @@ class ConversionStatistics:
     input_file: Path
     output_file: Path
     uniprot_chain_mappings: UniprotChainMappings
-
-
-def convert_to_cif_files(
-    input_files: Iterable[Path],
-    output_dir: Path,
-    copy_method: CopyMethod,
-    output_format: CifOutputFormat = ".cif",
-    pdb2uniprot: Pdb2UniprotChainsMapping | None = None,
-    chain_system: ChainIdSystem = "auth",
-) -> Generator[ConversionStatistics]:
-    """Convert structure files to CIF format.
-
-    Args:
-        input_files: Iterable of structure files to convert.
-        output_dir: Directory to save the converted files.
-        copy_method: How to copy when no changes are needed to output file.
-        output_format: Output file format to write.
-        pdb2uniprot: Optional dictionary mapping PDB ID to structured UniProt chain mappings.
-            If provided, will be used to inject UniProt accessions into structures that lack them.
-        chain_system: System of chain ids in ``pdb2uniprot`` mapping.
-
-    Yields:
-        ConversionStatistics for each converted file."""
-    for input_file in input_files:
-        stats = convert_to_cif_file(
-            input_file,
-            output_dir,
-            copy_method,
-            output_format=output_format,
-            pdb2uniprot=pdb2uniprot,
-            chain_system=chain_system,
-        )
-        yield stats
 
 
 def convert_to_cif_file(

--- a/tests/alphafold/test_confidence.py
+++ b/tests/alphafold/test_confidence.py
@@ -49,7 +49,7 @@ def test_filter_files_on_confidence(sample_pdb_file: Path, tmp_path: Path):
         min_residues=10,
     )
 
-    results = filter_files_on_confidence(input_files, query, tmp_path)
+    results = filter_files_on_confidence(input_files, query, tmp_path, scheduler_address="sequential")
 
     expected = [
         ConfidenceFilterResult(

--- a/tests/cli/test_convert.py
+++ b/tests/cli/test_convert.py
@@ -26,6 +26,8 @@ def test_convert_structures_to_cifgz(sample_cif: Path, tmp_path: Path, capsys: p
             str(output_dir),
             "--output-format",
             ".cif.gz",
+            "--scheduler-address",
+            "sequential",
         ]
     )
 
@@ -60,6 +62,8 @@ def test_convert_structures_with_injected_uniprot(no_uniprot_cif: Path, tmp_path
             ".cif.gz",
             "--uniprots",
             str(pdb2uniprotcsv),
+            "--scheduler-address",
+            "sequential",
         ]
     )
 
@@ -119,6 +123,8 @@ def test_convert_structures_with_injected_uniprot_chain_system(
             ".cif.gz",
             "--uniprots",
             str(pdb2uniprotcsv),
+            "--scheduler-address",
+            "sequential",
             *extra_args,
         ]
     )
@@ -153,6 +159,8 @@ def test_convert_structures_with_stats(sample_cif: Path, tmp_path: Path, capsys:
             ".cif.gz",
             "--write-stats",
             str(stats_fn),
+            "--scheduler-address",
+            "sequential",
         ]
     )
 
@@ -214,6 +222,8 @@ def test_convert_structures_with_stats_and_injection(
             str(pdb2uniprotcsv),
             "--write-stats",
             str(stats_fn),
+            "--scheduler-address",
+            "sequential",
         ]
     )
 
@@ -276,6 +286,8 @@ def test_convert_structures_with_stats_multiple_ranges(
             str(pdb2uniprotcsv),
             "--write-stats",
             str(stats_fn),
+            "--scheduler-address",
+            "sequential",
         ]
     )
 
@@ -317,7 +329,7 @@ def test_convert_clusters_writes_clusters_output(
     clusters_fn = tmp_path / "clusters.csv"
     stats_fn = tmp_path / "stats.csv"
 
-    main(["convert", "clusters", str(input_dir), str(clusters_fn)])
+    main(["convert", "clusters", str(input_dir), str(clusters_fn), "--scheduler-address", "sequential"])
 
     assert clusters_fn.exists()
     assert not stats_fn.exists()
@@ -363,6 +375,8 @@ def test_convert_clusters_optional_outputs(
             str(linkage_fn),
             "--dendrogram",
             str(dendrogram_dir),
+            "--scheduler-address",
+            "sequential",
         ]
     )
 

--- a/tests/cli/test_filter.py
+++ b/tests/cli/test_filter.py
@@ -270,6 +270,8 @@ def test_filter_secondary_structure(
         "symlink",
         "--write-stats",
         str(stats_fn),
+        "--scheduler-address",
+        "sequential",
     ]
 
     main(argv)

--- a/tests/filters/test_ss.py
+++ b/tests/filters/test_ss.py
@@ -9,7 +9,6 @@ from protein_quest.filters.ss import (
     SecondaryStructureFilterResult,
     SecondaryStructureStats,
     filter_file_on_secondary_structure,
-    filter_files_on_secondary_structure,
     filter_on_secondary_structure,
     nr_of_residues_in_helix,
     nr_of_residues_in_sheet,
@@ -131,13 +130,6 @@ def test_filter_file_on_secondary_structure(sample_cif: Path, sample_stats: Seco
     result = filter_file_on_secondary_structure(sample_cif, query)
     expected = SecondaryStructureFilterResult(stats=sample_stats, passed=True)
     assert result == expected
-
-
-def test_filter_files_on_secondary_structure(sample_cif: Path, sample_stats: SecondaryStructureStats):
-    query = SecondaryStructureFilterQuery(abs_min_helix_residues=1)
-    result = filter_files_on_secondary_structure([sample_cif], query)
-    expected = {sample_cif: SecondaryStructureFilterResult(stats=sample_stats, passed=True)}
-    assert dict(result) == expected
 
 
 def test_converter():

--- a/tests/structure/test_convert.py
+++ b/tests/structure/test_convert.py
@@ -2,26 +2,13 @@ from pathlib import Path
 
 import pytest
 
-from protein_quest.structure.convert import convert_to_cif_file, convert_to_cif_files, read_structure
+from protein_quest.structure.convert import convert_to_cif_file, read_structure
 from protein_quest.structure.formats import gunzip_file, structure2bcif, write_structure
 
 
 def test_convert_cifgz_to_cif(sample_cif: Path, tmp_path: Path):
     stats = convert_to_cif_file(sample_cif, tmp_path, copy_method="symlink")
 
-    assert stats.output_file.exists()
-    assert stats.output_file.name == "3jrs_updated_B2A.cif"
-    assert stats.output_file.stat().st_size > sample_cif.stat().st_size  # uncompressed file is larger
-    assert not stats.output_file.is_symlink()
-    assert stats.output_file.stat().st_nlink == 1  # not a hard link
-
-
-def test_convert_many_cifgz_to_cif(sample_cif: Path, tmp_path: Path):
-    results = list(convert_to_cif_files([sample_cif], tmp_path, copy_method="symlink"))
-
-    assert len(results) == 1
-    stats = results[0]
-    assert stats.input_file == sample_cif
     assert stats.output_file.exists()
     assert stats.output_file.name == "3jrs_updated_B2A.cif"
     assert stats.output_file.stat().st_size > sample_cif.stat().st_size  # uncompressed file is larger
@@ -81,24 +68,6 @@ def test_convert_cif_to_cifgz(sample_cif: Path, tmp_path: Path):
     assert stats.output_file.exists()
     assert stats.output_file.name == "3JRS_B2A.cif.gz"
     assert stats.output_file.stat().st_size > 0
-    assert (
-        read_structure(stats.output_file).make_pdb_string() == read_structure(uncompressed_cif_file).make_pdb_string()
-    )
-
-
-def test_convert_many_cif_to_cifgz(sample_cif: Path, tmp_path: Path):
-    uncompressed_cif_file = tmp_path / "3JRS_B2A.cif"
-    gunzip_file(sample_cif, uncompressed_cif_file)
-
-    results = list(
-        convert_to_cif_files([uncompressed_cif_file], tmp_path, copy_method="symlink", output_format=".cif.gz")
-    )
-
-    assert len(results) == 1
-    stats = results[0]
-    assert stats.input_file == uncompressed_cif_file
-    assert stats.output_file.exists()
-    assert stats.output_file.name == "3JRS_B2A.cif.gz"
     assert (
         read_structure(stats.output_file).make_pdb_string() == read_structure(uncompressed_cif_file).make_pdb_string()
     )


### PR DESCRIPTION
Add --scheduler-address to filter secondary-structure and `convert structures` commands.

