### PR TITLE
Switch from mkdocs + mkdocs-material to properdocs + mkdocs-materialx

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,4 +1,4 @@
-name: Deploy MkDocs to GitHub Pages
+name: Deploy properdocs to GitHub Pages
 
 on:
   push:
@@ -30,9 +30,9 @@ jobs:
       - name: Install dependencies
         run: uv sync --locked --group docs
 
-      - name: Build MkDocs site
+      - name: Build properdocs site
         run: |
-          uv run mkdocs build
+          uv run properdocs build
         env:
           # Force colored output from rich library
           TTY_COMPATIBLE: "1"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -113,13 +113,13 @@ uv sync --group docs
 Start the live-reloading docs server with:
 
 ```shell
-uv run mkdocs serve
+uv run properdocs serve
 ```
 
 Build the documentation site with:
 
 ```shell
-uv run mkdocs build
+uv run properdocs build
 # The site will be built in the `site/` directory.
 # You can preview it with
 python3 -m http.server -d site

--- a/properdocs.yml
+++ b/properdocs.yml
@@ -1,22 +1,36 @@
 site_name: Protein Quest
 site_url: https://bonvinlab.org/protein_quest
+site_description: Python package to search/retrieve/filter proteins and protein structures.
 repo_name: haddocking/protein-quest
 repo_url: https://github.com/haddocking/protein-quest
-watch: [mkdocs.yml, README.md, src/protein_quest]
+edit_uri: edit/main/docs/
+watch: [properdocs.yml, README.md, src/protein_quest]
 use_directory_urls: false
 theme:
-  name: material
+  name: materialx
+  code:
+    fold:
+      enabled: true
+  # font: false  # TODO renable with privacy plugin is fixed
   features:
-    - navigation.instant
     - navigation.tabs
     - navigation.tabs.sticky
+    - navigation.footer
+    - navigation.sections
     - content.code.copy
+    - content.action.view
+    - content.action.agents
+    - search.highlight
+    - search.share
+    - toc.follow
+  topbar_style: primary
   palette:
     # Palette toggle for automatic mode
     - media: "(prefers-color-scheme)"
       toggle:
         icon: material/brightness-auto
         name: Switch to light mode
+
     # Palette toggle for light mode
     - media: "(prefers-color-scheme: light)"
       scheme: default
@@ -25,6 +39,7 @@ theme:
       toggle:
         icon: material/brightness-7
         name: Switch to dark mode
+
     # Palette toggle for dark mode
     - media: "(prefers-color-scheme: dark)"
       scheme: slate
@@ -33,8 +48,13 @@ theme:
       toggle:
         icon: material/brightness-4
         name: Switch to system preference
+  icon:
+    repo: fontawesome/brands/github
 
 plugins:
+  # - privacy: # FileNotFoundError: [Errno 2] No such file or directory: '.../.cache/plugin/privacy/assets/external/zenodo.org/badge/DOI/10.5281/zenodo.16941288.svg'
+  #     assets_exclude:
+  #       - "https://doi.org/*"
   - search
   - autorefs
   - mkdocs-autoapi:
@@ -63,6 +83,21 @@ plugins:
   - cyclopts
 
 markdown_extensions:
+  - abbr
+  - admonition
+  - attr_list
+  - def_list
+  - footnotes
+  - md_in_html
+  - toc:
+      toc_depth: 4
+      permalink: true
+  - pymdownx.arithmatex:
+      generic: true
+  - pymdownx.betterem
+    # smart_enable: all
+  - pymdownx.caret
+  - pymdownx.details
   # Use to render part of README as home
   - pymdownx.snippets:
       base_path: [!relative $config_dir]
@@ -73,6 +108,21 @@ markdown_extensions:
         - name: mermaid
           class: mermaid
           format: !!python/name:pymdownx.superfences.fence_code_format
+          # TODO and pan/zoom/export
+          # see https://jaywhj.github.io/mkdocs-materialx/reference/diagrams.html?h=mermaid#customization
+          # and https://www.npmjs.com/package/@mostlylucid/mermaid-enhancements
+          # or others
+  - pymdownx.mark
+  - pymdownx.smartsymbols
+  - pymdownx.tabbed:
+      alternate_style: true
+      combine_header_slug: true
+      slugify: !!python/object/apply:pymdownx.slugs.slugify
+        kwds:
+          case: lower
+  - pymdownx.tasklist:
+      custom_checkbox: true
+  - pymdownx.tilde
 
 nav:
   - Home: index.md

--- a/properdocs.yml
+++ b/properdocs.yml
@@ -1,6 +1,7 @@
 site_name: Protein Quest
 site_url: https://bonvinlab.org/protein_quest
-site_description: Python package to search/retrieve/filter proteins and protein structures.
+site_description:
+  Python package to search/retrieve/filter proteins and protein structures.
 repo_name: haddocking/protein-quest
 repo_url: https://github.com/haddocking/protein-quest
 edit_uri: edit/main/docs/
@@ -11,7 +12,7 @@ theme:
   code:
     fold:
       enabled: true
-  # font: false  # TODO renable with privacy plugin is fixed
+  # font: false  # TODO re-nable with privacy plugin is fixed
   features:
     - navigation.tabs
     - navigation.tabs.sticky
@@ -108,10 +109,12 @@ markdown_extensions:
         - name: mermaid
           class: mermaid
           format: !!python/name:pymdownx.superfences.fence_code_format
-          # TODO and pan/zoom/export
-          # see https://jaywhj.github.io/mkdocs-materialx/reference/diagrams.html?h=mermaid#customization
-          # and https://www.npmjs.com/package/@mostlylucid/mermaid-enhancements
-          # or others
+            # TODO and pan/zoom/export
+            # see https://jaywhj.github.io/mkdocs-materialx/reference/diagrams.html?h=mermaid#customization
+            # and https://www.npmjs.com/package/@mostlylucid/mermaid-enhancements
+            # or others
+
+
   - pymdownx.mark
   - pymdownx.smartsymbols
   - pymdownx.tabbed:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,11 +85,11 @@ docs = [
     "cyclopts[mkdocs]>=4.5.4",
     "ipykernel>=6.29.5", # For notebook support in VS Code
     "ipywidgets", # For tqdm support in notebooks
-    "mkdocs>=1.6.1",
     "mkdocs-autoapi>=0.4.1",
     "mkdocs-jupyter>=0.25.1",
-    "mkdocs-material>=9.6.14",
+    "mkdocs-materialx>=10.2.0",
     "mkdocstrings-python>=2.0.2",
+    "properdocs>=1.6.7",
 ]
 
 [build-system]

--- a/src/protein_quest/pdbe_3dbeacons/model.py
+++ b/src/protein_quest/pdbe_3dbeacons/model.py
@@ -22,7 +22,7 @@ After generation changes:
 Also document UniprotSummary and its children:
 
 * Use google style docstrings using `Attributes:` section
-* as mkdocs does not understand docstring per property
+* as mkdocstrings does not understand docstring per property
 * make llm do it with following prompts:
 ```
 Document the children of UniprotSummary and AccessionListRequest.

--- a/uv.lock
+++ b/uv.lock
@@ -1611,6 +1611,20 @@ wheels = [
 ]
 
 [[package]]
+name = "mkdocs-document-dates"
+version = "3.8.7"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "babel" },
+    { name = "mkdocs" },
+    { name = "properdocs" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/47/9d/c77aedfdc4228b6aeb80d3ccc4d3c6e642b064f44e1ce47cef93101ff59d/mkdocs_document_dates-3.8.7.tar.gz", hash = "sha256:da03b4fcc5f94689a92791e96ff4b38cb967b6abce8a3a465fee849451aa5f1f", size = 195236, upload-time = "2026-06-19T06:27:40.37Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/10/7bd3e3a5edeb1dde352b5183a05819f8d2003958f17af42fade886cb025d/mkdocs_document_dates-3.8.7-py3-none-any.whl", hash = "sha256:9f9f699ad08080e1e8b5199820350d43e8c358c1de53bb6ef386bb360316eb9f", size = 200431, upload-time = "2026-06-19T06:27:38.882Z" },
+]
+
+[[package]]
 name = "mkdocs-get-deps"
 version = "0.2.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1670,6 +1684,31 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/79/9b/9b4c96d6593b2a541e1cb8b34899a6d021d208bb357042823d4d2cabdbe7/mkdocs_material_extensions-1.3.1.tar.gz", hash = "sha256:10c9511cea88f568257f960358a467d12b970e1f7b2c0e5fb2bb48cab1928443", size = 11847, upload-time = "2023-11-22T19:09:45.208Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/5b/54/662a4743aa81d9582ee9339d4ffa3c8fd40a4965e033d77b9da9774d3960/mkdocs_material_extensions-1.3.1-py3-none-any.whl", hash = "sha256:adff8b62700b25cb77b53358dad940f3ef973dd6db797907c49e3c2ef3ab4e31", size = 8728, upload-time = "2023-11-22T19:09:43.465Z" },
+]
+
+[[package]]
+name = "mkdocs-materialx"
+version = "10.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "babel" },
+    { name = "backrefs" },
+    { name = "colorama" },
+    { name = "jinja2" },
+    { name = "markdown" },
+    { name = "mkdocs" },
+    { name = "mkdocs-document-dates" },
+    { name = "mkdocs-material-extensions" },
+    { name = "pagefind", extra = ["extended"] },
+    { name = "paginate" },
+    { name = "properdocs" },
+    { name = "pygments" },
+    { name = "pymdown-extensions" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a4/2c/095a5fe0b7e0fc37d88f13b4cef0ba34e8ecfcdd43f6828ecb6e33eda52f/mkdocs_materialx-10.2.0.tar.gz", hash = "sha256:4ad6009fde5bdb59d2b98cabe1ee5f872aaf23470ed6c2ff29b7541f587a6a31", size = 4269100, upload-time = "2026-07-23T14:33:00.913Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/06/a2/2959404a107a95c15c4c3d80979a6b2ea3d305ec9924d7b3e2be7e7f0373/mkdocs_materialx-10.2.0-py3-none-any.whl", hash = "sha256:a912eb1ae76b7aa4c912995baa936f4acc17f06078c0f604f87757d18155c14f", size = 10219633, upload-time = "2026-07-23T14:32:38.814Z" },
 ]
 
 [[package]]
@@ -2031,6 +2070,33 @@ wheels = [
 ]
 
 [[package]]
+name = "pagefind"
+version = "1.5.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/50/cc/efc080eb3191d1afc75dc58c336676c0847fc4610b1d9e7d58b4083836b6/pagefind-1.5.2.tar.gz", hash = "sha256:fffddd6e2016b06bdca83b83d4ac4bef379cf0559f05ecdb6908a8729a27dbf3", size = 52521, upload-time = "2026-04-12T12:51:59.814Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0a/a7/414e1df2749f647784e32da78ce3081a9fedf1ae8d5b3bb8d4c5643f06cd/pagefind-1.5.2-py3-none-any.whl", hash = "sha256:6c4086ad9eaa7e8f863085652f6b1093549b1737848d946daa0706ee57f778d1", size = 10104, upload-time = "2026-04-12T12:51:27.563Z" },
+]
+
+[package.optional-dependencies]
+extended = [
+    { name = "pagefind-bin-extended" },
+]
+
+[[package]]
+name = "pagefind-bin-extended"
+version = "1.5.2"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/36/5e/06ac224460edfea99cca6708b25f7a604a2eec0c5db8d8b1a3b7246426cc/pagefind_bin_extended-1.5.2-py3-none-macosx_12_0_arm64.whl", hash = "sha256:9c4e2d7e0def5ba3a7814594e1d91cb6876030c5e05ccec53cc778b94d8af6e6", size = 52590084, upload-time = "2026-04-12T12:51:40.083Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/31/39ebf3ccfd440f377f4507d6232a5b27e6a55ba3296b6f63f766937727ef/pagefind_bin_extended-1.5.2-py3-none-macosx_12_0_x86_64.whl", hash = "sha256:c4db4b46e5aa42c6641cee257b0767895a1d9471c2332717763116e295bd7340", size = 52335482, upload-time = "2026-04-12T12:51:43.674Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/33/66cc2d32a8bfaa3dc4109a7a5f557a0df61aecee9fce827bd8ca9dbb051c/pagefind_bin_extended-1.5.2-py3-none-manylinux_2_12_x86_64.manylinux2010_x86_64.musllinux_1_1_x86_64.whl", hash = "sha256:1762f4a8c2137ca07261b0fec1b441df1ba421a0f124a86e33c43c09ca2d1d6c", size = 52658197, upload-time = "2026-04-12T12:51:46.937Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/a4/bdf91a227c0c7dcb394c4e47db1db046cd42e56d1881f61d8efbbadfd6e2/pagefind_bin_extended-1.5.2-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.musllinux_1_1_aarch64.whl", hash = "sha256:bcf47caa731c423c6ba355f593cf41febde986a296e8dd3a47620c72aa7a18e1", size = 52374465, upload-time = "2026-04-12T12:51:50.532Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/a7/fa14455f45f8b0ba7f99d9f51d7cbaeee26b187d8da3b457103977c6fd88/pagefind_bin_extended-1.5.2-py3-none-win_amd64.whl", hash = "sha256:2bf653ca30062b50e461887b14cd97be8e44dce6a28b9949b02db4b7f7ca694f", size = 52435085, upload-time = "2026-04-12T12:51:53.967Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/79/ea7a5edd10df47549fd2795d3e4183c08bd1ece96acc6445dd0b21b33f0e/pagefind_bin_extended-1.5.2-py3-none-win_arm64.whl", hash = "sha256:2a59c73b19857f84d7f3482c781897bd20d9409ab4b4e146d54c7b67713dd7cb", size = 52297865, upload-time = "2026-04-12T12:51:57.496Z" },
+]
+
+[[package]]
 name = "paginate"
 version = "0.5.7"
 source = { registry = "https://pypi.org/simple" }
@@ -2222,6 +2288,29 @@ wheels = [
 ]
 
 [[package]]
+name = "properdocs"
+version = "1.6.7"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "ghp-import" },
+    { name = "jinja2" },
+    { name = "markdown" },
+    { name = "markupsafe" },
+    { name = "packaging" },
+    { name = "pathspec" },
+    { name = "platformdirs" },
+    { name = "pyyaml" },
+    { name = "pyyaml-env-tag" },
+    { name = "watchdog" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ec/29/f27a4e1eddf72ed3db6e47818fbafe6debbf09fd7051f9c1a007239b46ef/properdocs-1.6.7.tar.gz", hash = "sha256:adc7b16e562890af0e098a7e5b02e3a81c20894a87d6a28d345c9300de73c26e", size = 276141, upload-time = "2026-03-20T20:07:48.167Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bd/4d/fc923f5c85318ee8cc903566dc4e0ebe41b2dfc1d2ecf5546db232397ed6/properdocs-1.6.7-py3-none-any.whl", hash = "sha256:6fa0cfa2e01bf338f684892c8a506cf70ea88ae7f3479c933b6fa20168101cbd", size = 225406, upload-time = "2026-03-20T20:07:46.875Z" },
+]
+
+[[package]]
 name = "protein-quest"
 source = { editable = "." }
 dependencies = [
@@ -2269,11 +2358,11 @@ docs = [
     { name = "cyclopts", extra = ["mkdocs"] },
     { name = "ipykernel" },
     { name = "ipywidgets" },
-    { name = "mkdocs" },
     { name = "mkdocs-autoapi" },
     { name = "mkdocs-jupyter" },
-    { name = "mkdocs-material" },
+    { name = "mkdocs-materialx" },
     { name = "mkdocstrings-python" },
+    { name = "properdocs" },
 ]
 type = [
     { name = "pyrefly" },
@@ -2325,11 +2414,11 @@ docs = [
     { name = "cyclopts", extras = ["mkdocs"], specifier = ">=4.5.4" },
     { name = "ipykernel", specifier = ">=6.29.5" },
     { name = "ipywidgets" },
-    { name = "mkdocs", specifier = ">=1.6.1" },
     { name = "mkdocs-autoapi", specifier = ">=0.4.1" },
     { name = "mkdocs-jupyter", specifier = ">=0.25.1" },
-    { name = "mkdocs-material", specifier = ">=9.6.14" },
+    { name = "mkdocs-materialx", specifier = ">=10.2.0" },
     { name = "mkdocstrings-python", specifier = ">=2.0.2" },
+    { name = "properdocs", specifier = ">=1.6.7" },
 ]
 type = [
     { name = "pyrefly", specifier = ">=1.1.1" },


### PR DESCRIPTION
Want to switch to mkdoc that is maintained.

Looked at [zensical](https://zensical.org/), but its missing support for plugins like autoapi, cyclopts and jupyter made it a no-go.

The forks approach is attainable.

