### PR TITLE
Add note for where diagram is rendered

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,8 @@ graph TB;
     convert2clusters:::dashedBorder
 ```
 
-(Dotted nodes and edges are side-quests.)
+(Dotted nodes and edges are side-quests.) (The Mermaid figure might not be rendered, see
+<https://www.bonvinlab.org/protein-quest/> for rendered version)
 
 ## Install
 

--- a/README.md
+++ b/README.md
@@ -83,8 +83,8 @@ graph TB;
     convert2clusters:::dashedBorder
 ```
 
-(Dotted nodes and edges are side-quests.) (The Mermaid figure might not be rendered, see
-<https://www.bonvinlab.org/protein-quest/> for rendered version)
+(Dotted nodes and edges are side-quests.) (The Mermaid figure might not be
+rendered, see <https://www.bonvinlab.org/protein-quest/> for rendered version)
 
 ## Install
 


### PR DESCRIPTION
Fixes #77

Also tried to convert diagtam to svg and embed.

```shell
docker run --rm -u `id -u`:`id -g` -v $PWD:/data minlag/mermaid-cli -i workflow.mermaid -o workflow.svg -b transparant 
```
but for rendering it on pypi we would need awkward non-relative url and svg is unaware of light/dark theme.