### PR TITLE
Handle structure with empty polymer chain

### DIFF
--- a/src/protein_quest/structure/uniprot.py
+++ b/src/protein_quest/structure/uniprot.py
@@ -122,6 +122,9 @@ def uniprot_chain_mappings_from_sifts(structure: gemmi.Structure) -> UniprotChai
     for model in structure:
         for chain in model:
             polymer = chain.get_polymer()
+            if not polymer:
+                logger.debug("Skipping empty polymer chain %s in structure %s", chain.name, structure.name)
+                continue
             subchain_id = polymer.subchain_id()
             entity_uniprots = sc2ua.get(subchain_id)
             if not entity_uniprots:

--- a/tests/cli/test_convert.py
+++ b/tests/cli/test_convert.py
@@ -312,6 +312,46 @@ def test_convert_structures_with_stats_multiple_ranges(
     assert "Statistics written to" in captured.err
 
 
+def test_convert_structures_with_empty_polymer(cif_1l5w: Path, tmp_path: Path, caplog: pytest.LogCaptureFixture):
+    caplog.set_level("DEBUG")
+    input_dir = tmp_path / "input"
+    input_dir.mkdir()
+    local_cif = input_dir / cif_1l5w.name
+    local_cif.symlink_to(cif_1l5w)
+    output_dir = tmp_path / "output"
+    pdb2uniprotcsv = tmp_path / "pdb2uniprot.csv"
+    with pdb2uniprotcsv.open("w", encoding="utf-8") as handle:
+        writer = csv.DictWriter(handle, fieldnames=["pdb_id", "uniprot_accession", "uniprot_chains"])
+        writer.writeheader()
+        writer.writerows(
+            [
+                {"pdb_id": "1L5W", "uniprot_accession": "P00490", "uniprot_chains": "A/B=2-797"},
+            ]
+        )
+
+    main(
+        [
+            "convert",
+            "structures",
+            str(input_dir),
+            "--output-dir",
+            str(output_dir),
+            "--output-format",
+            ".cif.gz",
+            "--uniprots",
+            str(pdb2uniprotcsv),
+            "--scheduler-address",
+            "sequential",
+        ]
+    )
+
+    # Check output file exists
+    output_file = output_dir / cif_1l5w.name
+    assert output_file.exists()
+    assert "Skipping empty polymer chain C in structure 1L5W" in caplog.text
+    assert "Skipping empty polymer chain D in structure 1L5W" in caplog.text
+
+
 def test_convert_clusters_writes_clusters_output(
     sample2_cif: Path,
     af_cif: Path,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -170,6 +170,15 @@ def cif_6o5i_updated() -> Path:
 
 
 @pytest.fixture
+def cif_1l5w() -> Path:
+    """1l5w structure with sugars on chain C and D."""
+    return fetch_cif(
+        "1l5w_updated.cif.gz",
+        "fe775b512a0816ba098577a13a8bf244b834ceef41f5b7860da02f340dfabb16",
+    )
+
+
+@pytest.fixture
 def xray_p05067_cifs(sample2_cif: Path, cif_2y2a: Path) -> list[Path]:
     return [sample2_cif, cif_2y2a]
 


### PR DESCRIPTION
Can not get subchain_id when polymer is empty residue span.

This PR skips chains with empty spans.