### PR TITLE
Rename pdb_id column to structure_id

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,6 +93,7 @@ docs = [
     "mkdocs-jupyter>=0.25.1",
     "mkdocs-materialx>=10.2.0",
     "mkdocstrings-python>=2.0.2",
+    "molviewspec>=1.8.1",
     "properdocs>=1.6.7",
 ]
 

--- a/src/protein_quest/__version__.py
+++ b/src/protein_quest/__version__.py
@@ -1,2 +1,2 @@
-__version__ = "1.6.1"
+__version__ = "1.7.0"
 """The version of the package."""

--- a/src/protein_quest/filters/combined.py
+++ b/src/protein_quest/filters/combined.py
@@ -64,7 +64,7 @@ class CombinedFilterResult:
 
     Parameters:
         input_file: Path to the input structure file.
-        pdb_id: PDB ID of the structure.
+        structure_id: Structure ID of the structure.
         metadata: Structure metadata.
         high_confidence_residues_count: Number of residues with high confidence (plDDT)
             for AlphaFold structures.
@@ -75,7 +75,7 @@ class CombinedFilterResult:
     """
 
     input_file: Path | None = None
-    pdb_id: str | None = None
+    structure_id: str | None = None
     metadata: StructureMetadata | None = None
     high_confidence_residues_count: int | None = None
     geometry_quality: float | None = None
@@ -85,10 +85,10 @@ class CombinedFilterResult:
 
     @property
     def id(self):
-        if not self.pdb_id:
-            msg = "pdb_id is not set"
+        if not self.structure_id:
+            msg = "structure_id is not set"
             raise ValueError(msg)
-        return self.pdb_id
+        return self.structure_id
 
     @property
     def resolution_value(self) -> float:
@@ -215,7 +215,7 @@ def _apply_alphafold_filter(
         )
     except Exception as e:  # noqa: BLE001
         return CombinedFilterResult(
-            pdb_id=metadata.id,
+            structure_id=metadata.id,
             input_file=input_file,
             geometry_quality=geometry_quality,
             metadata=metadata,
@@ -225,7 +225,7 @@ def _apply_alphafold_filter(
 
     if raw_result.filtered_file is None:
         return CombinedFilterResult(
-            pdb_id=metadata.id,
+            structure_id=metadata.id,
             input_file=input_file,
             geometry_quality=geometry_quality,
             metadata=metadata,
@@ -235,7 +235,7 @@ def _apply_alphafold_filter(
         )
 
     return CombinedFilterResult(
-        pdb_id=metadata.id,
+        structure_id=metadata.id,
         input_file=input_file,
         geometry_quality=geometry_quality,
         metadata=metadata,
@@ -247,7 +247,7 @@ def _apply_alphafold_filter(
 
 def _apply_non_alphafold_filters(
     input_file: Path,
-    pdb_id: str,
+    structure_id: str,
     metadata: StructureMetadata,
     geometry_quality: float | None,
     filters: CombinedFilterQuery,
@@ -258,7 +258,7 @@ def _apply_non_alphafold_filters(
         rrange = f"[{filters.min_residues}, {filters.max_residues}]"
         parts.processed.append(
             CombinedFilterResult(
-                pdb_id=pdb_id,
+                structure_id=structure_id,
                 input_file=input_file,
                 geometry_quality=geometry_quality,
                 metadata=metadata,
@@ -271,7 +271,7 @@ def _apply_non_alphafold_filters(
     if metadata.uniprot_accession and metadata.sequence_identity < filters.min_sequence_identity:
         parts.processed.append(
             CombinedFilterResult(
-                pdb_id=pdb_id,
+                structure_id=structure_id,
                 input_file=input_file,
                 geometry_quality=geometry_quality,
                 metadata=metadata,
@@ -303,7 +303,7 @@ def _apply_non_alphafold_filters(
         # TODO add min/max resolution filter? currently sorted and top N selected
         parts.resolution_only.append(
             CombinedFilterResult(
-                pdb_id=pdb_id,
+                structure_id=structure_id,
                 input_file=input_file,
                 metadata=metadata,
             )
@@ -315,7 +315,7 @@ def _apply_non_alphafold_filters(
         if geometry_quality < filters.min_geometry_quality:
             parts.processed.append(
                 CombinedFilterResult(
-                    pdb_id=pdb_id,
+                    structure_id=structure_id,
                     input_file=input_file,
                     geometry_quality=geometry_quality,
                     metadata=metadata,
@@ -326,7 +326,7 @@ def _apply_non_alphafold_filters(
             return parts
         parts.geometry_quality_only.append(
             CombinedFilterResult(
-                pdb_id=pdb_id,
+                structure_id=structure_id,
                 input_file=input_file,
                 geometry_quality=geometry_quality,
                 metadata=metadata,
@@ -336,7 +336,7 @@ def _apply_non_alphafold_filters(
 
     parts.processed.append(
         CombinedFilterResult(
-            pdb_id=pdb_id,
+            structure_id=structure_id,
             input_file=input_file,
             geometry_quality=geometry_quality,
             metadata=metadata,
@@ -372,9 +372,9 @@ def _partition_structure_file_and_apply_alphafold_filter(
         )
         return parts
 
-    pdb_id = structure.name
-    lowered_pdb_id = pdb_id.lower()
-    geometry_quality = scores[lowered_pdb_id].geometry_quality if lowered_pdb_id in scores else None
+    structure_id = structure.name
+    lowered_structure_id = structure_id.lower()
+    geometry_quality = scores[lowered_structure_id].geometry_quality if lowered_structure_id in scores else None
 
     try:
         metadata = structure_metadata(structure, path=input_file)
@@ -382,7 +382,7 @@ def _partition_structure_file_and_apply_alphafold_filter(
         logger.warning(f"Failed to extract metadata from {input_file}: {e}")
         parts.processed.append(
             CombinedFilterResult(
-                pdb_id=pdb_id,
+                structure_id=structure_id,
                 input_file=input_file,
                 geometry_quality=geometry_quality,
                 passed=False,
@@ -407,7 +407,7 @@ def _partition_structure_file_and_apply_alphafold_filter(
 
     return _apply_non_alphafold_filters(
         input_file=input_file,
-        pdb_id=pdb_id,
+        structure_id=structure_id,
         metadata=metadata,
         geometry_quality=geometry_quality,
         filters=filters,
@@ -494,7 +494,7 @@ def _top_clustered_results(
             if in_top and ok_quality:
                 output_file = output_dir / qs.input_file.name
                 fresult = CombinedFilterResult(
-                    pdb_id=qs.id,
+                    structure_id=qs.id,
                     input_file=qs.input_file,
                     geometry_quality=qs.geometry_quality,
                     metadata=qs.metadata,
@@ -510,7 +510,7 @@ def _top_clustered_results(
                 if not ok_quality:
                     reason.append(f"Geometry quality {qs.geometry_quality} below minimum {minimal_geometry_quality}")
                 fresult = CombinedFilterResult(
-                    pdb_id=qs.id,
+                    structure_id=qs.id,
                     input_file=qs.input_file,
                     geometry_quality=qs.geometry_quality,
                     metadata=qs.metadata,
@@ -701,7 +701,7 @@ def combined_filter_summary(
 def combined_filter_stats(results: list[CombinedFilterResult], path: StdioPath):
     fieldnames = [
         "input_file",
-        "pdb_id",
+        "structure_id",
         "uniprot_accession",
         "resolution",
         "high_confidence_residues_count",
@@ -723,7 +723,7 @@ def combined_filter_stats(results: list[CombinedFilterResult], path: StdioPath):
         for result in results:
             row: dict[str, str | Path | int | float | None] = {
                 "input_file": result.input_file,
-                "pdb_id": result.pdb_id,
+                "structure_id": result.structure_id,
                 "geometry_quality": result.geometry_quality,
                 "high_confidence_residues_count": result.high_confidence_residues_count,
                 "resolution": result.resolution_value,

--- a/src/protein_quest/structure/convert.py
+++ b/src/protein_quest/structure/convert.py
@@ -90,7 +90,12 @@ def convert_to_cif_file(
         new_structure, _, uniprot_chain_mappings = add_uniprot_accessions2structure(
             structure, pdb2uniprot, chain_system=chain_system
         )
-        write_structure(new_structure, output_file)
+        if structure is new_structure and extension == output_format:
+            msg = "File %s is already in %s format and does not need change, copying to %s"
+            logger.info(msg, input_file, output_format, output_dir)
+            copyfile(input_file, output_file, copy_method)
+        else:
+            write_structure(new_structure, output_file)
     elif extension == ".cif":
         if output_format == ".cif":
             logger.info("File %s is already in .cif format, copying to %s", input_file, output_dir)

--- a/src/protein_quest/structure/convert.py
+++ b/src/protein_quest/structure/convert.py
@@ -45,6 +45,97 @@ class ConversionStatistics:
     uniprot_chain_mappings: UniprotChainMappings
 
 
+def _validate_output_format(output_format: CifOutputFormat) -> None:
+    if output_format not in cif_output_formats:
+        msg = f"Unsupported output format {output_format}. Supported output formats are: {cif_output_formats}."
+        raise ValueError(msg)
+
+
+def _new_conversion_statistics(
+    input_file: Path,
+    output_file: Path,
+    uniprot_chain_mappings: UniprotChainMappings | None = None,
+) -> ConversionStatistics:
+    return ConversionStatistics(
+        input_file=input_file,
+        output_file=output_file,
+        uniprot_chain_mappings=set() if uniprot_chain_mappings is None else uniprot_chain_mappings,
+    )
+
+
+def _handle_existing_output_file(input_file: Path, output_file: Path) -> ConversionStatistics:
+    logger.info("Output file %s already exists for input file %s. Skipping.", output_file, input_file)
+    return _new_conversion_statistics(input_file, output_file)
+
+
+def _handle_pdb_like_input(
+    input_file: Path,
+    output_file: Path,
+    output_format: CifOutputFormat,
+    copy_method: CopyMethod,
+    pdb2uniprot: Pdb2UniprotChainsMapping | None,
+    chain_system: ChainIdSystem,
+    extension: str,
+) -> ConversionStatistics:
+    structure = read_structure(input_file)
+    new_structure, _, uniprot_chain_mappings = add_uniprot_accessions2structure(
+        structure, pdb2uniprot, chain_system=chain_system
+    )
+    if structure is new_structure and extension == output_format:
+        msg = "File %s is already in %s format and does not need change, copying to %s"
+        logger.info(msg, input_file, output_format, output_file.parent)
+        copyfile(input_file, output_file, copy_method)
+        return _new_conversion_statistics(input_file, output_file, uniprot_chain_mappings)
+
+    write_structure(new_structure, output_file)
+    return _new_conversion_statistics(input_file, output_file, uniprot_chain_mappings)
+
+
+def _handle_cif_input(
+    input_file: Path,
+    output_file: Path,
+    output_format: CifOutputFormat,
+    copy_method: CopyMethod,
+) -> ConversionStatistics:
+    if output_format == ".cif":
+        logger.info("File %s is already in .cif format, copying to %s", input_file, output_file.parent)
+        copyfile(input_file, output_file, copy_method)
+        return _new_conversion_statistics(input_file, output_file)
+
+    structure = read_structure(input_file)
+    write_structure(structure, output_file)
+    return _new_conversion_statistics(input_file, output_file)
+
+
+def _handle_cif_gz_input(
+    input_file: Path,
+    output_file: Path,
+    output_format: CifOutputFormat,
+    copy_method: CopyMethod,
+) -> ConversionStatistics:
+    if output_format == ".cif":
+        gunzip_file(input_file, output_file=output_file, keep_original=True)
+        return _new_conversion_statistics(input_file, output_file)
+
+    copyfile(input_file, output_file, copy_method)
+    return _new_conversion_statistics(input_file, output_file)
+
+
+def _handle_bcif_input(
+    input_file: Path,
+    output_file: Path,
+    output_format: CifOutputFormat,
+) -> ConversionStatistics:
+    if output_format == ".cif":
+        with output_file.open("w") as f:
+            f.write(bcif2cif(input_file))
+        return _new_conversion_statistics(input_file, output_file)
+
+    structure = read_structure(input_file)
+    write_structure(structure, output_file)
+    return _new_conversion_statistics(input_file, output_file)
+
+
 def convert_to_cif_file(
     input_file: Path,
     output_dir: Path,
@@ -74,59 +165,39 @@ def convert_to_cif_file(
     Raises:
         ValueError: If the requested output format is not supported."""
     logger.debug("Converting %s", input_file)
-    if output_format not in cif_output_formats:
-        msg = f"Unsupported output format {output_format}. Supported output formats are: {cif_output_formats}."
-        raise ValueError(msg)
+    _validate_output_format(output_format)
 
     name, extension = split_name_and_extension(input_file.name)
     output_file = output_dir / f"{name}{output_format}"
 
-    uniprot_chain_mappings: UniprotChainMappings = set()
-
     if output_file.exists():
-        logger.info("Output file %s already exists for input file %s. Skipping.", output_file, input_file)
-    elif pdb2uniprot or extension in {".pdb", ".pdb.gz", ".ent", ".ent.gz"}:
-        structure = read_structure(input_file)
-        new_structure, _, uniprot_chain_mappings = add_uniprot_accessions2structure(
-            structure, pdb2uniprot, chain_system=chain_system
-        )
-        if structure is new_structure and extension == output_format:
-            msg = "File %s is already in %s format and does not need change, copying to %s"
-            logger.info(msg, input_file, output_format, output_dir)
-            copyfile(input_file, output_file, copy_method)
-        else:
-            write_structure(new_structure, output_file)
-    elif extension == ".cif":
-        if output_format == ".cif":
-            logger.info("File %s is already in .cif format, copying to %s", input_file, output_dir)
-            copyfile(input_file, output_file, copy_method)
-        else:
-            structure = read_structure(input_file)
-            write_structure(structure, output_file)
-    elif extension == ".cif.gz":
-        if output_format == ".cif":
-            gunzip_file(input_file, output_file=output_file, keep_original=True)
-        else:
-            copyfile(input_file, output_file, copy_method)
-    elif extension == ".bcif":
-        if output_format == ".cif":
-            with output_file.open("w") as f:
-                f.write(bcif2cif(input_file))
-        else:
-            structure = read_structure(input_file)
-            write_structure(structure, output_file)
-    else:
-        msg = (
-            f"Unsupported file extension {extension} in {input_file}. "
-            f"Supported extensions are {valid_structure_file_extensions}."
-        )
-        raise ValueError(msg)
+        return _handle_existing_output_file(input_file, output_file)
 
-    return ConversionStatistics(
-        input_file=input_file,
-        output_file=output_file,
-        uniprot_chain_mappings=uniprot_chain_mappings,
+    if pdb2uniprot or extension in {".pdb", ".pdb.gz", ".ent", ".ent.gz"}:
+        return _handle_pdb_like_input(
+            input_file=input_file,
+            output_file=output_file,
+            output_format=output_format,
+            copy_method=copy_method,
+            pdb2uniprot=pdb2uniprot,
+            chain_system=chain_system,
+            extension=extension,
+        )
+
+    if extension == ".cif":
+        return _handle_cif_input(input_file, output_file, output_format, copy_method)
+
+    if extension == ".cif.gz":
+        return _handle_cif_gz_input(input_file, output_file, output_format, copy_method)
+
+    if extension == ".bcif":
+        return _handle_bcif_input(input_file, output_file, output_format)
+
+    msg = (
+        f"Unsupported file extension {extension} in {input_file}. "
+        f"Supported extensions are {valid_structure_file_extensions}."
     )
+    raise ValueError(msg)
 
 
 def write_conversion_stats(

--- a/src/protein_quest/structure/formats.py
+++ b/src/protein_quest/structure/formats.py
@@ -134,13 +134,15 @@ def _is_em_method(structure: gemmi.Structure) -> bool:
 
 def _make_mmcif_document(structure: gemmi.Structure) -> gemmi.cif.Document:
     """Create an mmCIF document and preserve EM resolution metadata when needed."""
-    # do not write chem_comp so it is viewable by molstar
-    # see https://github.com/project-gemmi/gemmi/discussions/362
-    doc = structure.make_mmcif_document(gemmi.MmcifOutputGroups(True, chem_comp=False))
+    doc = structure.make_mmcif_document()
     block = doc.sole_block()
 
     _add_em_3d_reconstruction(structure, block)
     _add_sifts_xref_db(structure, block)
+    # TODO set _chem_comp.type from current always False to correct value, see
+    # https://github.com/project-gemmi/gemmi/discussions/362
+    # and
+    # https://mmcif.wwpdb.org/dictionaries/mmcif_pdbx_v50.dic/Items/_chem_comp.type.html
     return doc
 
 

--- a/src/protein_quest/structure/formats.py
+++ b/src/protein_quest/structure/formats.py
@@ -21,6 +21,108 @@ from protein_quest.utils import user_cache_root_dir
 logger = logging.getLogger(__name__)
 
 
+def _sifts_polymer_rows(structure: gemmi.Structure) -> dict[str, list[str]]:
+    """Build minimal SIFTS residue rows for mmCIF output.
+
+    Gemmi reconstructs ``Entity.sifts_unp_acc`` and ``Residue.sifts_unp`` from
+    ``_pdbx_sifts_xref_db`` when reading mmCIF. This helper only emits the
+    subset of columns needed for that roundtrip.
+
+    Args:
+        structure: Structure whose polymer residues may contain SIFTS UniProt
+            annotations.
+
+    Returns:
+        Mapping of ``_pdbx_sifts_xref_db`` column names to row values. Returns
+        empty column lists when the structure has no SIFTS residue annotations
+        that can be written safely.
+    """
+    rows: dict[str, list[str]] = {
+        "entity_id": [],
+        "asym_id": [],
+        "seq_id_ordinal": [],
+        "seq_id": [],
+        "observed": [],
+        "unp_res": [],
+        "unp_num": [],
+        "unp_acc": [],
+    }
+    subchain_to_entity = {
+        subchain: entity for entity in structure.entities for subchain in entity.subchains if entity.sifts_unp_acc
+    }
+
+    for model in structure:
+        for chain in model:
+            polymer = chain.get_polymer()
+            if not polymer:
+                continue
+            subchain_id = polymer.subchain_id()
+            entity = subchain_to_entity.get(subchain_id)
+            if entity is None:
+                continue
+
+            for residue in polymer:
+                unp_res, acc_index, unp_num = residue.sifts_unp
+                if unp_num <= 0 or not unp_res:
+                    continue
+                rows["entity_id"].append(entity.name)
+                rows["asym_id"].append(subchain_id)
+                # Gemmi only consumes rows with seq_id_ordinal == 1.
+                rows["seq_id_ordinal"].append("1")
+                rows["seq_id"].append(str(residue.label_seq))
+                rows["observed"].append("y")
+                rows["unp_res"].append(unp_res)
+                rows["unp_num"].append(str(unp_num))
+                rows["unp_acc"].append(entity.sifts_unp_acc[acc_index])
+
+    return rows
+
+
+def _add_sifts_xref_db(structure: gemmi.Structure, block: gemmi.cif.Block):
+    """Append minimal SIFTS residue annotations to an mmCIF block.
+
+    This is needed because the mmCIF document produced by Gemmi is missing the
+    ``_pdbx_sifts_xref_db`` category, even when the input structure still has
+    SIFTS UniProt annotations in memory.
+
+    Args:
+        structure: Structure that may contain in-memory SIFTS annotations on
+            entities and residues.
+        block: mmCIF block produced for ``structure`` that should receive the
+            ``_pdbx_sifts_xref_db`` category when SIFTS rows are available.
+    """
+    rows = _sifts_polymer_rows(structure)
+    if not rows["entity_id"]:
+        return
+    block.set_mmcif_category("_pdbx_sifts_xref_db.", rows)
+
+
+def _add_em_3d_reconstruction(structure: gemmi.Structure, block: gemmi.cif.Block):
+    """Append EM reconstruction resolution metadata to an mmCIF block.
+
+    This is needed because Gemmi reads EM resolution from
+    ``_em_3d_reconstruction.resolution`` into ``Structure.resolution``, but the
+    generated mmCIF document does not recreate that category automatically.
+
+    Args:
+        structure: Structure whose EM resolution metadata may need to be
+            restored to the output mmCIF block.
+        block: mmCIF block produced for ``structure`` that should receive the
+            ``_em_3d_reconstruction`` fields when they are missing.
+    """
+    if structure.resolution <= 0 or not _is_em_method(structure):
+        return
+    if block.get_mmcif_category("_em_3d_reconstruction.resolution"):
+        msg = (
+            "Gemmi has support for _em_3d_reconstruction, please create "
+            "issue to remove _add_em_3d_reconstruction function"
+        )
+        raise ValueError(msg)
+    block.set_pair("_em_3d_reconstruction.entry_id", structure.name)
+    block.set_pair("_em_3d_reconstruction.id", "1")
+    block.set_pair("_em_3d_reconstruction.resolution", str(structure.resolution))
+
+
 def _is_em_method(structure: gemmi.Structure) -> bool:
     # Could have used ./metadata.py::_structure_method, but do not to prevent circular import
     try:
@@ -35,14 +137,10 @@ def _make_mmcif_document(structure: gemmi.Structure) -> gemmi.cif.Document:
     # do not write chem_comp so it is viewable by molstar
     # see https://github.com/project-gemmi/gemmi/discussions/362
     doc = structure.make_mmcif_document(gemmi.MmcifOutputGroups(True, chem_comp=False))
-    # Gemmi reads EM resolution into Structure.resolution from
-    # _em_3d_reconstruction.resolution, but does not emit that category again.
-    if structure.resolution > 0 and _is_em_method(structure):
-        block = doc.sole_block()
-        if not block.find_value("_em_3d_reconstruction.resolution"):
-            block.set_pair("_em_3d_reconstruction.entry_id", structure.name)
-            block.set_pair("_em_3d_reconstruction.id", "1")
-            block.set_pair("_em_3d_reconstruction.resolution", str(structure.resolution))
+    block = doc.sole_block()
+
+    _add_em_3d_reconstruction(structure, block)
+    _add_sifts_xref_db(structure, block)
     return doc
 
 

--- a/src/protein_quest/structure/formats.py
+++ b/src/protein_quest/structure/formats.py
@@ -112,7 +112,7 @@ def _add_em_3d_reconstruction(structure: gemmi.Structure, block: gemmi.cif.Block
     """
     if structure.resolution <= 0 or not _is_em_method(structure):
         return
-    if block.get_mmcif_category("_em_3d_reconstruction.resolution"):
+    if block.get_mmcif_category("_em_3d_reconstruction."):
         msg = (
             "Gemmi has support for _em_3d_reconstruction, please create "
             "issue to remove _add_em_3d_reconstruction function"

--- a/tests/cli/test_convert.py
+++ b/tests/cli/test_convert.py
@@ -84,7 +84,9 @@ def test_convert_structures_with_injected_uniprot(no_uniprot_cif: Path, tmp_path
     assert injected_uniprot == expected
 
 
-def test_convert_structures_with_uniprots_keeps_issue_155_accessions(cif_3plz: Path, tmp_path: Path):
+def test_convert_structures_with_uniprots_keeps_issue_155_accessions(
+    cif_3plz: Path, tmp_path: Path, caplog: pytest.LogCaptureFixture
+):
     input_dir = tmp_path / "input"
     input_dir.mkdir()
     local_cif = input_dir / cif_3plz.name
@@ -97,40 +99,44 @@ def test_convert_structures_with_uniprots_keeps_issue_155_accessions(cif_3plz: P
         writer.writeheader()
         writer.writerow({"pdb_id": "3PLZ", "uniprot_accession": "Q9UEC0", "uniprot_chains": "A=300-541"})
 
-    main(
-        [
-            "convert",
-            "structures",
-            str(input_dir),
-            "--output-dir",
-            str(output_dir),
-            "--output-format",
-            ".cif.gz",
-            "--uniprots",
-            str(pdb2uniprotcsv),
-            "--scheduler-address",
-            "sequential",
-        ]
-    )
+    with caplog.at_level("INFO"):
+        main(
+            [
+                "convert",
+                "structures",
+                str(input_dir),
+                "--output-dir",
+                str(output_dir),
+                "--output-format",
+                ".cif.gz",
+                "--uniprots",
+                str(pdb2uniprotcsv),
+                "--scheduler-address",
+                "sequential",
+            ]
+        )
 
     output_file = output_dir / cif_3plz.name
     assert output_file.exists()
-
     structure = read_structure(output_file)
-
-    sift_kept = {
-        (mapping.chain_id, mapping.uniprot_accession)
-        for mapping in structure_to_uniprot(structure, source="sifts", one_uniprot_per_chain=False)
-        if mapping.chain_id == "A"
-    }
-    assert ("A", "Q9UEC0") in sift_kept
-
     struct_ref_kept = {
         (mapping.chain_id, mapping.uniprot_accession)
         for mapping in structure_to_uniprot(structure, source="struct_ref_seq", one_uniprot_per_chain=False)
         if mapping.chain_id == "A"
     }
-    assert ("A", "O00482") in struct_ref_kept
+    sift_kept = {
+        (mapping.chain_id, mapping.uniprot_accession)
+        for mapping in structure_to_uniprot(structure, source="sifts", one_uniprot_per_chain=False)
+        if mapping.chain_id == "A"
+    }
+    expected = {"struct_ref_seq": {("A", "Q9UEC0")}, "sifts": {("A", "O00482")}}
+    kept = {
+        "struct_ref_seq": struct_ref_kept,
+        "sifts": sift_kept,
+    }
+    assert kept == expected
+
+    assert "format and does not need change, copying to" in caplog.text
 
 
 @pytest.mark.parametrize(

--- a/tests/cli/test_convert.py
+++ b/tests/cli/test_convert.py
@@ -84,6 +84,55 @@ def test_convert_structures_with_injected_uniprot(no_uniprot_cif: Path, tmp_path
     assert injected_uniprot == expected
 
 
+def test_convert_structures_with_uniprots_keeps_issue_155_accessions(cif_3plz: Path, tmp_path: Path):
+    input_dir = tmp_path / "input"
+    input_dir.mkdir()
+    local_cif = input_dir / cif_3plz.name
+    local_cif.symlink_to(cif_3plz)
+    output_dir = tmp_path / "output"
+
+    pdb2uniprotcsv = tmp_path / "pdb2uniprot.csv"
+    with pdb2uniprotcsv.open("w", encoding="utf-8") as handle:
+        writer = csv.DictWriter(handle, fieldnames=["pdb_id", "uniprot_accession", "uniprot_chains"])
+        writer.writeheader()
+        writer.writerow({"pdb_id": "3PLZ", "uniprot_accession": "Q9UEC0", "uniprot_chains": "A=300-541"})
+
+    main(
+        [
+            "convert",
+            "structures",
+            str(input_dir),
+            "--output-dir",
+            str(output_dir),
+            "--output-format",
+            ".cif.gz",
+            "--uniprots",
+            str(pdb2uniprotcsv),
+            "--scheduler-address",
+            "sequential",
+        ]
+    )
+
+    output_file = output_dir / cif_3plz.name
+    assert output_file.exists()
+
+    structure = read_structure(output_file)
+
+    sift_kept = {
+        (mapping.chain_id, mapping.uniprot_accession)
+        for mapping in structure_to_uniprot(structure, source="sifts", one_uniprot_per_chain=False)
+        if mapping.chain_id == "A"
+    }
+    assert ("A", "Q9UEC0") in sift_kept
+
+    struct_ref_kept = {
+        (mapping.chain_id, mapping.uniprot_accession)
+        for mapping in structure_to_uniprot(structure, source="struct_ref_seq", one_uniprot_per_chain=False)
+        if mapping.chain_id == "A"
+    }
+    assert ("A", "O00482") in struct_ref_kept
+
+
 @pytest.mark.parametrize(
     ("chain_id", "extra_args"),
     [

--- a/tests/cli/test_filter.py
+++ b/tests/cli/test_filter.py
@@ -225,6 +225,8 @@ class TestFilterChain:
         output_files = {path.name for path in tmp_path.glob("*8rw8*_B2A.cif.gz")}
         assert len(output_files) == 1
 
+    # TODO add test like test_convert_structures_with_uniprots_keeps_issue_155_accessions that verifies O00482 is still present when filtered on chain A
+
 
 def test_filter_residue(sample_cif: Path, sample2_cif: Path, tmp_path: Path, capsys: pytest.CaptureFixture[str]):
     """Test filter residue command."""

--- a/tests/cli/test_filter.py
+++ b/tests/cli/test_filter.py
@@ -8,6 +8,8 @@ from pathlib import Path
 import pytest
 
 from protein_quest.cli import main
+from protein_quest.structure.formats import read_structure
+from protein_quest.structure.uniprot import FlattenedUniprotChainMapping, structure_to_uniprot
 
 
 class TestFilterChain:
@@ -225,7 +227,59 @@ class TestFilterChain:
         output_files = {path.name for path in tmp_path.glob("*8rw8*_B2A.cif.gz")}
         assert len(output_files) == 1
 
-    # TODO add test like test_convert_structures_with_uniprots_keeps_issue_155_accessions that verifies O00482 is still present when filtered on chain A
+    def test_keeps_sifts(self, cif_3plz: Path, tmp_path: Path):
+        input_dir = tmp_path / "input"
+        input_dir.mkdir()
+        output_dir = tmp_path / "output"
+
+        local_cif = input_dir / cif_3plz.name
+        local_cif.symlink_to(cif_3plz)
+        chains_fn = tmp_path / "chains.csv"
+        chains_fn.write_text("pdb_id,chain\n3plz,A\n")
+
+        argv = [
+            "filter",
+            "chain",
+            str(chains_fn),
+            str(input_dir),
+            str(output_dir),
+            "--scheduler-address",
+            "sequential",
+        ]
+
+        main(argv)
+
+        output_file = output_dir / "3plz_updated_A2A.cif.gz"
+        assert output_file.exists()
+
+        structure = read_structure(output_file)
+        result_uniprots = {
+            "struct_ref_seq": structure_to_uniprot(structure, source="struct_ref_seq", one_uniprot_per_chain=False),
+            "sifts": structure_to_uniprot(structure, source="sifts", one_uniprot_per_chain=False),
+        }
+        expected = {
+            "struct_ref_seq": {
+                FlattenedUniprotChainMapping(
+                    uniprot_accession="Q9UEC0",
+                    uniprot_start=300,
+                    uniprot_end=541,
+                    chain_id="A",
+                    sequence_identity=1.0,
+                    aligned_residue_count=242,
+                ),
+            },
+            "sifts": {
+                FlattenedUniprotChainMapping(
+                    uniprot_accession="O00482",
+                    uniprot_start=300,
+                    uniprot_end=538,
+                    chain_id="A",
+                    sequence_identity=0.9665271966527197,  # TODO make portable by comparing with pytest approx helpers via dict
+                    aligned_residue_count=231,
+                ),
+            },
+        }
+        assert result_uniprots == expected
 
 
 def test_filter_residue(sample_cif: Path, sample2_cif: Path, tmp_path: Path, capsys: pytest.CaptureFixture[str]):

--- a/tests/cli/test_filter.py
+++ b/tests/cli/test_filter.py
@@ -12,6 +12,26 @@ from protein_quest.structure.formats import read_structure
 from protein_quest.structure.uniprot import FlattenedUniprotChainMapping, structure_to_uniprot
 
 
+def normalize_uniprot_chain_mappings(
+    mappings: dict[str, set[FlattenedUniprotChainMapping]],
+) -> dict[str, set[FlattenedUniprotChainMapping]]:
+    normalized: dict[str, set[FlattenedUniprotChainMapping]] = {}
+    for source, source_mappings in mappings.items():
+        normalized[source] = {
+            FlattenedUniprotChainMapping(
+                uniprot_accession=mapping.uniprot_accession,
+                uniprot_start=mapping.uniprot_start,
+                uniprot_end=mapping.uniprot_end,
+                chain_id=mapping.chain_id,
+                sequence_identity=round(mapping.sequence_identity, 4),
+                aligned_residue_count=mapping.aligned_residue_count,
+            )
+            for mapping in source_mappings
+        }
+
+    return normalized
+
+
 class TestFilterChain:
     def test_happy_path(self, sample2_cif: Path, tmp_path: Path, capsys: pytest.CaptureFixture[str]):
         """Test filter chain command with valid input."""
@@ -274,12 +294,12 @@ class TestFilterChain:
                     uniprot_start=300,
                     uniprot_end=538,
                     chain_id="A",
-                    sequence_identity=0.9665271966527197,  # TODO make portable by comparing with pytest approx helpers via dict
+                    sequence_identity=0.9665,
                     aligned_residue_count=231,
                 ),
             },
         }
-        assert result_uniprots == expected
+        assert normalize_uniprot_chain_mappings(result_uniprots) == normalize_uniprot_chain_mappings(expected)
 
 
 def test_filter_residue(sample_cif: Path, sample2_cif: Path, tmp_path: Path, capsys: pytest.CaptureFixture[str]):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -170,6 +170,15 @@ def cif_6o5i_updated() -> Path:
 
 
 @pytest.fixture
+def cif_3plz() -> Path:
+    """3PLZ structure with both Q9UEC0 and O00482 UniProt accessions on the same chain."""
+    return fetch_cif(
+        "3plz_updated.cif.gz",
+        "4f706acddcdaca54e3a28cb59dcd362c111536f566f2a15803b15996d3717de7",
+    )
+
+
+@pytest.fixture
 def cif_1l5w() -> Path:
     """1l5w structure with sugars on chain C and D."""
     return fetch_cif(

--- a/tests/filters/test_combined.py
+++ b/tests/filters/test_combined.py
@@ -67,7 +67,7 @@ class TestCombinedFilter:
         expected = [
             CombinedFilterResult(
                 input_file=input_dir / "AF-A0A0C5B5G6-F1-model_v6.cif.gz",
-                pdb_id="AF-A0A0C5B5G6-F1",
+                structure_id="AF-A0A0C5B5G6-F1",
                 metadata=StructureMetadata(
                     id="AF-A0A0C5B5G6-F1",
                     uniprot_accession="A0A0C5B5G6",
@@ -90,7 +90,7 @@ class TestCombinedFilter:
             ),
             CombinedFilterResult(
                 input_file=input_dir / "1amb_updated.cif.gz",
-                pdb_id="1AMB",
+                structure_id="1AMB",
                 metadata=StructureMetadata(
                     id="1AMB",
                     uniprot_accession="P05067",
@@ -113,7 +113,7 @@ class TestCombinedFilter:
             ),
             CombinedFilterResult(
                 input_file=input_dir / "3jrs_updated_B2A.cif.gz",
-                pdb_id="3JRS",
+                structure_id="3JRS",
                 metadata=StructureMetadata(
                     id="3JRS",
                     uniprot_accession="Q8VZS8",
@@ -136,7 +136,7 @@ class TestCombinedFilter:
             ),
             CombinedFilterResult(
                 input_file=input_dir / "2Y29.cif.gz",
-                pdb_id="2Y29",
+                structure_id="2Y29",
                 metadata=StructureMetadata(
                     id="2Y29",
                     uniprot_accession="P05067",
@@ -159,7 +159,7 @@ class TestCombinedFilter:
             ),
             CombinedFilterResult(
                 input_file=input_dir / "6O5I.cif.gz",
-                pdb_id="6O5I",
+                structure_id="6O5I",
                 metadata=StructureMetadata(
                     id="6O5I",
                     uniprot_accession="O00255",
@@ -182,7 +182,7 @@ class TestCombinedFilter:
             ),
             CombinedFilterResult(
                 input_file=input_dir / "1un5.cif.gz",
-                pdb_id="1UN5",
+                structure_id="1UN5",
                 metadata=StructureMetadata(
                     id="1UN5",
                     uniprot_accession="P03950",
@@ -205,7 +205,7 @@ class TestCombinedFilter:
             ),
             CombinedFilterResult(
                 input_file=input_dir / "8w77_updated.cif.gz",
-                pdb_id="8W77",
+                structure_id="8W77",
                 metadata=StructureMetadata(
                     id="8W77",
                     uniprot_accession="P0ABE7",
@@ -247,7 +247,7 @@ class TestCombinedFilter:
         expected = [
             CombinedFilterResult(
                 input_file=input_dir / "unreadable.cif",
-                pdb_id=None,
+                structure_id=None,
                 metadata=None,
                 high_confidence_residues_count=None,
                 geometry_quality=None,
@@ -257,7 +257,7 @@ class TestCombinedFilter:
             ),
             CombinedFilterResult(
                 input_file=input_dir / "atomless.cif",
-                pdb_id=" ",
+                structure_id=" ",
                 metadata=None,
                 high_confidence_residues_count=None,
                 geometry_quality=None,
@@ -267,7 +267,7 @@ class TestCombinedFilter:
             ),
             CombinedFilterResult(
                 input_file=input_dir / "no_uniprot.cif",
-                pdb_id="2Y29",
+                structure_id="2Y29",
                 metadata=StructureMetadata(
                     id="2Y29",
                     uniprot_accession=None,
@@ -313,7 +313,7 @@ class TestCombinedFilter:
         expected = [
             CombinedFilterResult(
                 input_file=input_file,
-                pdb_id="1AMB",
+                structure_id="1AMB",
                 metadata=StructureMetadata(
                     id="1AMB",
                     uniprot_accession="P05067",
@@ -354,7 +354,7 @@ class TestCombinedFilter:
         expected = [
             CombinedFilterResult(
                 input_file=input_file,
-                pdb_id="AF-A0A0C5B5G6-F1",
+                structure_id="AF-A0A0C5B5G6-F1",
                 metadata=StructureMetadata(
                     id="AF-A0A0C5B5G6-F1",
                     uniprot_accession="A0A0C5B5G6",
@@ -395,7 +395,7 @@ class TestCombinedFilter:
         expected = [
             CombinedFilterResult(
                 input_file=input_file,
-                pdb_id="2Y29",
+                structure_id="2Y29",
                 metadata=StructureMetadata(
                     id="2Y29",
                     uniprot_accession="P05067",
@@ -439,7 +439,7 @@ class TestCombinedFilter:
         expected = [
             CombinedFilterResult(
                 input_file=input_dir / "2y2a_updated.cif.gz",
-                pdb_id="2Y2A",
+                structure_id="2Y2A",
                 metadata=StructureMetadata(
                     id="2Y2A",
                     uniprot_accession="P05067",
@@ -462,7 +462,7 @@ class TestCombinedFilter:
             ),
             CombinedFilterResult(
                 input_file=input_dir / "2Y29.cif.gz",
-                pdb_id="2Y29",
+                structure_id="2Y29",
                 metadata=StructureMetadata(
                     id="2Y29",
                     uniprot_accession="P05067",
@@ -530,7 +530,7 @@ class TestCombinedFilter:
         expected = [
             CombinedFilterResult(
                 input_file=input_dir / "2Y29.cif",
-                pdb_id="2Y29",
+                structure_id="2Y29",
                 metadata=StructureMetadata(
                     id="2Y29",
                     uniprot_accession="P05067",
@@ -553,7 +553,7 @@ class TestCombinedFilter:
             ),
             CombinedFilterResult(
                 input_file=input_dir / "2y2a_updated.cif",
-                pdb_id="2Y2A",
+                structure_id="2Y2A",
                 metadata=StructureMetadata(
                     id="2Y2A",
                     uniprot_accession="P05067",
@@ -590,7 +590,7 @@ class TestCombinedFilter:
         expected = [
             CombinedFilterResult(
                 input_file=input_dir / "2Y29.cif",
-                pdb_id="2Y29",
+                structure_id="2Y29",
                 metadata=StructureMetadata(
                     id="2Y29",
                     uniprot_accession="P05067",
@@ -613,7 +613,7 @@ class TestCombinedFilter:
             ),
             CombinedFilterResult(
                 input_file=input_dir / "2y2a_updated.cif",
-                pdb_id="2Y2A",
+                structure_id="2Y2A",
                 metadata=StructureMetadata(
                     id="2Y2A",
                     uniprot_accession="P05067",
@@ -655,7 +655,7 @@ class TestCombinedFilter:
         expected = [
             CombinedFilterResult(
                 input_file=input_file,
-                pdb_id="2Y29",
+                structure_id="2Y29",
                 metadata=StructureMetadata(
                     id="2Y29",
                     uniprot_accession=None,
@@ -742,7 +742,7 @@ class TestCombinedFilter:
         expected = [
             CombinedFilterResult(
                 input_file=input_dir / "6O5I.cif.gz",
-                pdb_id="6O5I",
+                structure_id="6O5I",
                 metadata=StructureMetadata(
                     id="6O5I",
                     uniprot_accession="O00255",
@@ -765,7 +765,7 @@ class TestCombinedFilter:
             ),
             CombinedFilterResult(
                 input_file=input_dir / "1un5.cif.gz",
-                pdb_id="1UN5",
+                structure_id="1UN5",
                 metadata=StructureMetadata(
                     id="1UN5",
                     uniprot_accession="P03950",
@@ -795,7 +795,7 @@ def fake_results() -> list[CombinedFilterResult]:
     return [
         CombinedFilterResult(
             input_file=Path("file1.cif"),
-            pdb_id="1ABC",
+            structure_id="1ABC",
             metadata=StructureMetadata(
                 id="1ABC",
                 uniprot_accession="P12345",
@@ -818,7 +818,7 @@ def fake_results() -> list[CombinedFilterResult]:
         ),
         CombinedFilterResult(
             input_file=Path("file2.cif"),
-            pdb_id="2DEF",
+            structure_id="2DEF",
             metadata=StructureMetadata(
                 id="2DEF",
                 uniprot_accession=None,
@@ -841,7 +841,7 @@ def fake_results() -> list[CombinedFilterResult]:
         ),
         CombinedFilterResult(
             input_file=Path("file3.cif"),
-            pdb_id="AF-3GHI",
+            structure_id="AF-3GHI",
             metadata=StructureMetadata(
                 id="AF-3GHI",
                 uniprot_accession="A0ABCD",
@@ -864,7 +864,7 @@ def fake_results() -> list[CombinedFilterResult]:
         ),
         CombinedFilterResult(
             input_file=Path("file4.cif"),
-            pdb_id="4JKL",
+            structure_id="4JKL",
             metadata=StructureMetadata(
                 id="4JKL",
                 uniprot_accession="P99999",
@@ -887,7 +887,7 @@ def fake_results() -> list[CombinedFilterResult]:
         ),
         CombinedFilterResult(
             input_file=Path("file5.cif"),
-            pdb_id="AF-5MNO",
+            structure_id="AF-5MNO",
             metadata=StructureMetadata(
                 id="AF-5MNO",
                 uniprot_accession="A1BCDE",
@@ -965,7 +965,7 @@ def test_combined_filter_stats(fake_results: list[CombinedFilterResult], tmp_pat
                 "method": "X-ray",
                 "output_file": "output/file1.cif",
                 "passed": "True",
-                "pdb_id": "1ABC",
+                "structure_id": "1ABC",
                 "reason": "",
                 "resolution": "2.0",
                 "sequence_identity": "1.0",
@@ -983,7 +983,7 @@ def test_combined_filter_stats(fake_results: list[CombinedFilterResult], tmp_pat
                 "method": "NMR",
                 "output_file": "",
                 "passed": "False",
-                "pdb_id": "2DEF",
+                "structure_id": "2DEF",
                 "reason": "No UniProt accession, no resolution, no geometry quality",
                 "resolution": "0.0",
                 "sequence_identity": "0.0",
@@ -1001,7 +1001,7 @@ def test_combined_filter_stats(fake_results: list[CombinedFilterResult], tmp_pat
                 "method": "Predicted",
                 "output_file": "output/file3.cif",
                 "passed": "True",
-                "pdb_id": "AF-3GHI",
+                "structure_id": "AF-3GHI",
                 "reason": "",
                 "resolution": "0.0",
                 "sequence_identity": "1.0",
@@ -1019,7 +1019,7 @@ def test_combined_filter_stats(fake_results: list[CombinedFilterResult], tmp_pat
                 "method": "X-ray",
                 "output_file": "",
                 "passed": "False",
-                "pdb_id": "4JKL",
+                "structure_id": "4JKL",
                 "reason": "Resolution 4.5 > 4.0",
                 "resolution": "4.5",
                 "sequence_identity": "0.7",
@@ -1037,7 +1037,7 @@ def test_combined_filter_stats(fake_results: list[CombinedFilterResult], tmp_pat
                 "method": "Predicted",
                 "output_file": "",
                 "passed": "False",
-                "pdb_id": "AF-5MNO",
+                "structure_id": "AF-5MNO",
                 "reason": "High confidence residue ratio too low",
                 "resolution": "0.0",
                 "sequence_identity": "1.0",
@@ -1051,7 +1051,7 @@ def test_combined_filter_stats(fake_results: list[CombinedFilterResult], tmp_pat
 
         expected_fieldnames = [
             "input_file",
-            "pdb_id",
+            "structure_id",
             "uniprot_accession",
             "resolution",
             "high_confidence_residues_count",

--- a/tests/structure/test_formats.py
+++ b/tests/structure/test_formats.py
@@ -11,20 +11,10 @@ from protein_quest.structure.formats import (
     write_structure,
 )
 from protein_quest.structure.types import valid_structure_file_extensions
+from protein_quest.structure.uniprot import structure_to_uniprot
 
 
-@pytest.mark.parametrize("extension", valid_structure_file_extensions)
-def test_write_structure(sample2_cif: Path, tmp_path: Path, extension: str):
-    structure = read_structure(sample2_cif)
-    output_file = tmp_path / f"bla{extension}"
-
-    write_structure(structure, output_file)
-
-    assert output_file.exists()
-    assert output_file.stat().st_size > 0
-
-
-def test_write_structure_invalid_extension(sample2_cif: Path, tmp_path: Path):
+def test_invalid_extension(sample2_cif: Path, tmp_path: Path):
     structure = read_structure(sample2_cif)
     output_file = tmp_path / "bla.txt"
 
@@ -63,32 +53,80 @@ def test_gunzip_of_non_gz_file(tmp_path: Path):
         gunzip_file(input_file)
 
 
-@pytest.mark.parametrize(
-    ["output_fn"],
-    [
-        ("em_structure.cif",),
-        ("em_structure.cif.gz",),
-    ],
-)
-def test_em_structure_retains_resolution(em_cif: Path, tmp_path: Path, output_fn: str):
-    structure = read_structure(em_cif)
-    assert structure.resolution == 3.61
-    output_file = tmp_path / output_fn
+class TestWriteStructure:
+    @pytest.mark.parametrize("extension", valid_structure_file_extensions)
+    def test_extensions(self, sample2_cif: Path, tmp_path: Path, extension: str):
+        structure = read_structure(sample2_cif)
+        output_file = tmp_path / f"bla{extension}"
 
-    write_structure(structure, output_file)
+        write_structure(structure, output_file)
 
-    written_structure = read_structure(output_file)
+        assert output_file.exists()
+        assert output_file.stat().st_size > 0
 
-    assert written_structure.resolution == 3.61
+    @pytest.mark.parametrize(
+        ["output_fn"],
+        [
+            ("em_structure.cif",),
+            ("em_structure.cif.gz",),
+        ],
+    )
+    def test_em_structure_retains_resolution(self, em_cif: Path, tmp_path: Path, output_fn: str):
+        structure = read_structure(em_cif)
+        assert structure.resolution == 3.61
+        output_file = tmp_path / output_fn
 
+        write_structure(structure, output_file)
 
-def test_em_archived_structure_retains_resolution(fake_archive_em_structure: gemmi.Structure, tmp_path: Path):
-    structure = fake_archive_em_structure
-    assert structure.resolution == 4.2
-    output_file = tmp_path / "em_structure.cif"
+        written_structure = read_structure(output_file)
 
-    write_structure(structure, output_file)
+        assert written_structure.resolution == 3.61
 
-    written_structure = read_structure(output_file)
+    def test_em_archived_structure_retains_resolution(self, fake_archive_em_structure: gemmi.Structure, tmp_path: Path):
+        structure = fake_archive_em_structure
+        assert structure.resolution == 4.2
+        output_file = tmp_path / "em_structure.cif"
 
-    assert written_structure.resolution == 4.2
+        write_structure(structure, output_file)
+
+        written_structure = read_structure(output_file)
+
+        assert written_structure.resolution == 4.2
+
+    def test_keeps_sifts_roundtrip(self, cif_3plz: Path, tmp_path: Path):
+        structure = read_structure(cif_3plz)
+        expected = structure_to_uniprot(structure, source="sifts", one_uniprot_per_chain=False)
+        assert len(expected) == 4
+        output_file = tmp_path / "3plz_roundtrip.cif.gz"
+
+        write_structure(structure, output_file)
+
+        written_structure = read_structure(output_file)
+        result = structure_to_uniprot(written_structure, source="sifts", one_uniprot_per_chain=False)
+        assert len(result) == 4
+
+        assert result == expected
+
+    def test_keeps_sifts_with_empty_polymer_chains(self, cif_1l5w: Path, tmp_path: Path):
+        structure = read_structure(cif_1l5w)
+        expected = structure_to_uniprot(structure, source="sifts", one_uniprot_per_chain=False)
+        assert len(expected) == 2
+        output_file = tmp_path / "1l5w_roundtrip.cif.gz"
+
+        write_structure(structure, output_file)
+
+        written_structure = read_structure(output_file)
+        result = structure_to_uniprot(written_structure, source="sifts", one_uniprot_per_chain=False)
+
+        assert result == expected
+
+    def test_omits_sifts_block_without_sifts(self, sample2_cif: Path, tmp_path: Path):
+        structure = read_structure(sample2_cif)
+        assert structure_to_uniprot(structure, source="sifts", one_uniprot_per_chain=False) == set()
+        output_file = tmp_path / "2y29_roundtrip.cif.gz"
+
+        write_structure(structure, output_file)
+
+        observed_cif_text = gzip.decompress(output_file.read_bytes()).decode("utf-8")
+
+        assert "_pdbx_sifts_xref_db." not in observed_cif_text

--- a/tests/structure/test_formats.py
+++ b/tests/structure/test_formats.py
@@ -3,6 +3,7 @@ from pathlib import Path
 
 import gemmi
 import pytest
+from gemmi import cif
 
 from protein_quest.structure.formats import (
     gunzip_file,
@@ -130,3 +131,17 @@ class TestWriteStructure:
         observed_cif_text = gzip.decompress(output_file.read_bytes()).decode("utf-8")
 
         assert "_pdbx_sifts_xref_db." not in observed_cif_text
+
+    def test_retains_chem_comp_id_not_type(self, cif_1l5w: Path, tmp_path: Path):
+        original_block = cif.read_file(str(cif_1l5w)).sole_block()
+        structure = read_structure(cif_1l5w)
+        output_file = tmp_path / "1l5w_roundtrip.cif.gz"
+
+        write_structure(structure, output_file)
+
+        written_block = cif.read_file(str(output_file)).sole_block()
+        expected_block: dict[str, list[str] | list[bool]] = {
+            "id": list(original_block.find_values("_chem_comp.id")),
+        }
+        expected_block["type"] = [False] * len(expected_block["id"])
+        assert written_block.get_mmcif_category("_chem_comp") == expected_block

--- a/tests/structure/test_uniprot.py
+++ b/tests/structure/test_uniprot.py
@@ -818,6 +818,18 @@ def test_structure_to_uniprot_allow_multiple_accessions_per_chain(multi_accessio
     assert actual == expected
 
 
+def test_structure_to_uniprot_issue_155_keeps_all_accessions_for_single_chain(cif_3plz: Path):
+    """Regression test for issue #155: mixed SIFTS + struct_ref_seq data should keep both accessions."""
+    structure = read_structure(cif_3plz)
+
+    actual = structure_to_uniprot(structure, source="both", one_uniprot_per_chain=False)
+
+    assert {(mapping.chain_id, mapping.uniprot_accession) for mapping in actual if mapping.chain_id == "A"} == {
+        ("A", "Q9UEC0"),
+        ("A", "O00482"),
+    }
+
+
 def test_structure_to_uniprot_bad_source(sample2_cif: Path):
     structure = read_structure(sample2_cif)
 

--- a/uv.lock
+++ b/uv.lock
@@ -2378,6 +2378,7 @@ docs = [
     { name = "mkdocs-jupyter" },
     { name = "mkdocs-materialx" },
     { name = "mkdocstrings-python" },
+    { name = "molviewspec" },
     { name = "properdocs" },
 ]
 type = [
@@ -2436,6 +2437,7 @@ docs = [
     { name = "mkdocs-jupyter", specifier = ">=0.25.1" },
     { name = "mkdocs-materialx", specifier = ">=10.2.0" },
     { name = "mkdocstrings-python", specifier = ">=2.0.2" },
+    { name = "molviewspec", specifier = ">=1.8.1" },
     { name = "properdocs", specifier = ">=1.6.7" },
 ]
 type = [


### PR DESCRIPTION
in stats csv file of `filter combined` command

The combined filter handls PDB and Alphafold. So make column more generic.

This PR also
- [x] makes `convert structures` faster if nothing needs to be changed
- [x] on writing cif structure retains the uniprot accession in SIFT cross references, before SIFT entries where forgotten (refs #155 and fixes it for single span uniprot, but not for multiple spans see #156)
- [x] include partial chem_comp block during writing cif structure so mol* renders it with a bit more info.